### PR TITLE
Can't override primary button's classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Bugfixes:
 
   - Use #underscore, not #downcase for help text scope (#140, @atipugin)
   - Radio button and checkbox labels will now include the disabled class as needed. (#156, @ScottSwezey)
+  - Can't override primary button classes (#183, @tanimichi)
 
 Features:
 

--- a/lib/bootstrap_form/helpers/bootstrap.rb
+++ b/lib/bootstrap_form/helpers/bootstrap.rb
@@ -2,7 +2,7 @@ module BootstrapForm
   module Helpers
     module Bootstrap
       def submit(name = nil, options = {})
-        options.merge! class: 'btn btn-default' unless options.has_key? :class
+        options.reverse_merge! class: 'btn btn-default'
         super(name, options)
       end
 

--- a/lib/bootstrap_form/helpers/bootstrap.rb
+++ b/lib/bootstrap_form/helpers/bootstrap.rb
@@ -7,7 +7,7 @@ module BootstrapForm
       end
 
       def primary(name = nil, options = {})
-        options.merge! class: 'btn btn-primary'
+        options.reverse_merge! class: 'btn btn-primary'
         submit(name, options)
       end
 

--- a/test/bootstrap_other_components_test.rb
+++ b/test/bootstrap_other_components_test.rb
@@ -51,4 +51,9 @@ class BootstrapOtherComponentsTest < ActionView::TestCase
     expected = %{<input class="btn btn-primary" name="commit" type="submit" value="Submit Form" />}
     assert_equal expected, @builder.primary("Submit Form")
   end
+
+  test "override primary button classes" do
+    expected = %{<input class="btn btn-primary disabled" name="commit" type="submit" value="Submit Form" />}
+    assert_equal expected, @builder.primary("Submit Form", class: "btn btn-primary disabled")
+  end
 end


### PR DESCRIPTION
Hi,

Primary button classes aren't overridden when you pass classes as the option.

```ruby
= post.primary 'create', class: 'btn btn-primary disabled' # disabled class is ignored!!
```

That's becase [Hash#merge use other_hash's value](http://www.ruby-doc.org/core-2.1.5/Hash.html#method-i-merge).

```ruby
options = { class: 'btn btn-primary disabled ' }
options.merge! class: 'btn btn-primary' #=> {:class=>"btn btn-primary"}
```

[ActiveSupport's reverse_merge](http://api.rubyonrails.org/classes/ActiveSupport/HashWithIndifferentAccess.html#method-i-reverse_merge) takes care of this problem.

```ruby
options = { class: 'btn btn-primary disabled ' }
options.reverse_merge! class: 'btn btn-primary' #=> {:class=>"btn btn-primary disabled"}
```

Thanks.