### PR TITLE
Allow callable value_method and text_method for collection_check_boxes and collection_radio_buttons

### DIFF
--- a/lib/bootstrap_form/form_builder.rb
+++ b/lib/bootstrap_form/form_builder.rb
@@ -363,17 +363,18 @@ module BootstrapForm
         inputs = ""
 
         collection.each do |obj|
-          input_options = options.merge(label: obj.send(text))
+          input_options = options.merge(label: text.respond_to?(:call) ? text.call(obj) : obj.send(text))
 
+          input_value = value.respond_to?(:call) ? value.call(obj) : obj.send(value)
           if checked = input_options[:checked]
-            input_options[:checked] = checked == obj.send(value)              ||
-                                      checked.try(:include?, obj.send(value)) ||
-                                      checked == obj                          ||
-                                      checked.try(:include?, obj)
+            input_options[:checked] = checked == input_value                     ||
+                                      Array(checked).try(:include?, input_value) ||
+                                      checked == obj                             ||
+                                      Array(checked).try(:include?, obj)
           end
 
           input_options.delete(:class)
-          inputs << block.call(name, obj.send(value), input_options)
+          inputs << block.call(name, input_value, input_options)
         end
 
         inputs.html_safe

--- a/test/bootstrap_checkbox_test.rb
+++ b/test/bootstrap_checkbox_test.rb
@@ -88,4 +88,50 @@ class BootstrapCheckboxTest < ActionView::TestCase
     assert_equal expected, @builder.collection_check_boxes(:misc, collection, :id, :street, checked: [1, 2])
     assert_equal expected, @builder.collection_check_boxes(:misc, collection, :id, :street, checked: collection)
   end
+
+  test 'collection_check_boxes renders multiple checkboxes with labels defined by Proc :text_method correctly' do
+    collection = [Address.new(id: 1, street: 'Foo'), Address.new(id: 2, street: 'Bar')]
+    expected = %{<input id="user_misc" multiple="multiple" name="user[misc][]" type="hidden" value="" /><div class="form-group"><label class="control-label" for="user_misc">Misc</label><div class="checkbox"><label for="user_misc_1"><input id="user_misc_1" name="user[misc][]" type="checkbox" value="1" /> ooF</label></div><div class="checkbox"><label for="user_misc_2"><input id="user_misc_2" name="user[misc][]" type="checkbox" value="2" /> raB</label></div></div>}
+
+    assert_equal expected, @builder.collection_check_boxes(:misc, collection, :id, Proc.new { |a| a.street.reverse })
+  end
+
+  test 'collection_check_boxes renders multiple checkboxes with values defined by Proc :value_method correctly' do
+    collection = [Address.new(id: 1, street: 'Foo'), Address.new(id: 2, street: 'Bar')]
+    expected = %{<input id="user_misc" multiple="multiple" name="user[misc][]" type="hidden" value="" /><div class="form-group"><label class="control-label" for="user_misc">Misc</label><div class="checkbox"><label for="user_misc_address_1"><input id="user_misc_address_1" name="user[misc][]" type="checkbox" value="address_1" /> Foo</label></div><div class="checkbox"><label for="user_misc_address_2"><input id="user_misc_address_2" name="user[misc][]" type="checkbox" value="address_2" /> Bar</label></div></div>}
+
+    assert_equal expected, @builder.collection_check_boxes(:misc, collection, Proc.new { |a| "address_#{a.id}" }, :street)
+  end
+
+  test 'collection_check_boxes renders multiple checkboxes with labels defined by lambda :text_method correctly' do
+    collection = [Address.new(id: 1, street: 'Foo'), Address.new(id: 2, street: 'Bar')]
+    expected = %{<input id="user_misc" multiple="multiple" name="user[misc][]" type="hidden" value="" /><div class="form-group"><label class="control-label" for="user_misc">Misc</label><div class="checkbox"><label for="user_misc_1"><input id="user_misc_1" name="user[misc][]" type="checkbox" value="1" /> ooF</label></div><div class="checkbox"><label for="user_misc_2"><input id="user_misc_2" name="user[misc][]" type="checkbox" value="2" /> raB</label></div></div>}
+
+    assert_equal expected, @builder.collection_check_boxes(:misc, collection, :id, lambda { |a| a.street.reverse })
+  end
+
+  test 'collection_check_boxes renders multiple checkboxes with values defined by lambda :value_method correctly' do
+    collection = [Address.new(id: 1, street: 'Foo'), Address.new(id: 2, street: 'Bar')]
+    expected = %{<input id="user_misc" multiple="multiple" name="user[misc][]" type="hidden" value="" /><div class="form-group"><label class="control-label" for="user_misc">Misc</label><div class="checkbox"><label for="user_misc_address_1"><input id="user_misc_address_1" name="user[misc][]" type="checkbox" value="address_1" /> Foo</label></div><div class="checkbox"><label for="user_misc_address_2"><input id="user_misc_address_2" name="user[misc][]" type="checkbox" value="address_2" /> Bar</label></div></div>}
+
+    assert_equal expected, @builder.collection_check_boxes(:misc, collection, lambda { |a| "address_#{a.id}" }, :street)
+  end
+
+  test 'collection_check_boxes renders with checked option correctly with Proc :value_method' do
+    collection = [Address.new(id: 1, street: 'Foo'), Address.new(id: 2, street: 'Bar')]
+    expected = %{<input id="user_misc" multiple="multiple" name="user[misc][]" type="hidden" value="" /><div class="form-group"><label class="control-label" for="user_misc">Misc</label><div class="checkbox"><label for="user_misc_address_1"><input checked="checked" id="user_misc_address_1" name="user[misc][]" type="checkbox" value="address_1" /> Foo</label></div><div class="checkbox"><label for="user_misc_address_2"><input id="user_misc_address_2" name="user[misc][]" type="checkbox" value="address_2" /> Bar</label></div></div>}
+
+    assert_equal expected, @builder.collection_check_boxes(:misc, collection, Proc.new { |a| "address_#{a.id}" }, :street, checked: "address_1")
+    assert_equal expected, @builder.collection_check_boxes(:misc, collection, Proc.new { |a| "address_#{a.id}" }, :street, checked: collection.first)
+  end
+
+  test 'collection_check_boxes renders with multiple checked options correctly with lambda :value_method' do
+    collection = [Address.new(id: 1, street: 'Foo'), Address.new(id: 2, street: 'Bar')]
+    expected = %{<input id="user_misc" multiple="multiple" name="user[misc][]" type="hidden" value="" /><div class="form-group"><label class="control-label" for="user_misc">Misc</label><div class="checkbox"><label for="user_misc_address_1"><input checked="checked" id="user_misc_address_1" name="user[misc][]" type="checkbox" value="address_1" /> Foo</label></div><div class="checkbox"><label for="user_misc_address_2"><input checked="checked" id="user_misc_address_2" name="user[misc][]" type="checkbox" value="address_2" /> Bar</label></div></div>}
+
+    assert_equal expected, @builder.collection_check_boxes(:misc, collection, lambda { |a| "address_#{a.id}" }, :street, checked: ["address_1", "address_2"])
+    assert_equal expected, @builder.collection_check_boxes(:misc, collection, lambda { |a| "address_#{a.id}" }, :street, checked: collection)
+  end
+
+
 end

--- a/test/bootstrap_radio_button_test.rb
+++ b/test/bootstrap_radio_button_test.rb
@@ -64,4 +64,61 @@ class BootstrapRadioButtonTest < ActionView::TestCase
 
     assert_equal expected, @builder.collection_radio_buttons(:misc, collection, :id, :street, checked: 1)
   end
+
+  test 'collection_radio_buttons renders label defined by Proc correctly' do
+    collection = [Address.new(id: 1, street: 'Foobar')]
+    expected = %{<div class="form-group"><label class="control-label" for="user_misc">This is a radio button collection</label><div class="radio"><label for="user_misc_1"><input id="user_misc_1" name="user[misc]" type="radio" value="1" /> rabooF</label></div><span class="help-block">With a help!</span></div>}
+
+    assert_equal expected, @builder.collection_radio_buttons(:misc, collection, :id, Proc.new { |a| a.street.reverse }, label: 'This is a radio button collection', help: 'With a help!')
+  end
+
+  test 'collection_radio_buttons renders value defined by Proc correctly' do
+    collection = [Address.new(id: 1, street: 'Foobar')]
+    expected = %{<div class="form-group"><label class="control-label" for="user_misc">This is a radio button collection</label><div class="radio"><label for="user_misc_address_1"><input id="user_misc_address_1" name="user[misc]" type="radio" value="address_1" /> Foobar</label></div><span class="help-block">With a help!</span></div>}
+
+    assert_equal expected, @builder.collection_radio_buttons(:misc, collection, Proc.new { |a| "address_#{a.id}" }, :street, label: 'This is a radio button collection', help: 'With a help!')
+  end
+
+  test 'collection_radio_buttons renders multiple radios with label defined by Proc correctly' do
+    collection = [Address.new(id: 1, street: 'Foo'), Address.new(id: 2, street: 'Bar')]
+    expected = %{<div class="form-group"><label class="control-label" for="user_misc">Misc</label><div class="radio"><label for="user_misc_1"><input id="user_misc_1" name="user[misc]" type="radio" value="1" /> ooF</label></div><div class="radio"><label for="user_misc_2"><input id="user_misc_2" name="user[misc]" type="radio" value="2" /> raB</label></div></div>}
+
+    assert_equal expected, @builder.collection_radio_buttons(:misc, collection, :id, Proc.new { |a| a.street.reverse })
+  end
+
+  test 'collection_radio_buttons renders multiple radios with value defined by Proc correctly' do
+    collection = [Address.new(id: 1, street: 'Foo'), Address.new(id: 2, street: 'Bar')]
+    expected = %{<div class="form-group"><label class="control-label" for="user_misc">Misc</label><div class="radio"><label for="user_misc_address_1"><input id="user_misc_address_1" name="user[misc]" type="radio" value="address_1" /> Foo</label></div><div class="radio"><label for="user_misc_address_2"><input id="user_misc_address_2" name="user[misc]" type="radio" value="address_2" /> Bar</label></div></div>}
+
+    assert_equal expected, @builder.collection_radio_buttons(:misc, collection, Proc.new { |a| "address_#{a.id}" }, :street)
+  end
+
+  test 'collection_radio_buttons renders label defined by lambda correctly' do
+    collection = [Address.new(id: 1, street: 'Foobar')]
+    expected = %{<div class="form-group"><label class="control-label" for="user_misc">This is a radio button collection</label><div class="radio"><label for="user_misc_1"><input id="user_misc_1" name="user[misc]" type="radio" value="1" /> rabooF</label></div><span class="help-block">With a help!</span></div>}
+
+    assert_equal expected, @builder.collection_radio_buttons(:misc, collection, :id, lambda { |a| a.street.reverse }, label: 'This is a radio button collection', help: 'With a help!')
+  end
+
+  test 'collection_radio_buttons renders value defined by lambda correctly' do
+    collection = [Address.new(id: 1, street: 'Foobar')]
+    expected = %{<div class="form-group"><label class="control-label" for="user_misc">This is a radio button collection</label><div class="radio"><label for="user_misc_address_1"><input id="user_misc_address_1" name="user[misc]" type="radio" value="address_1" /> Foobar</label></div><span class="help-block">With a help!</span></div>}
+
+    assert_equal expected, @builder.collection_radio_buttons(:misc, collection, lambda { |a| "address_#{a.id}" }, :street, label: 'This is a radio button collection', help: 'With a help!')
+  end
+
+  test 'collection_radio_buttons renders multiple radios with label defined by lambda correctly' do
+    collection = [Address.new(id: 1, street: 'Foo'), Address.new(id: 2, street: 'Bar')]
+    expected = %{<div class="form-group"><label class="control-label" for="user_misc">Misc</label><div class="radio"><label for="user_misc_1"><input id="user_misc_1" name="user[misc]" type="radio" value="1" /> ooF</label></div><div class="radio"><label for="user_misc_2"><input id="user_misc_2" name="user[misc]" type="radio" value="2" /> raB</label></div></div>}
+
+    assert_equal expected, @builder.collection_radio_buttons(:misc, collection, :id, lambda { |a| a.street.reverse })
+  end
+
+  test 'collection_radio_buttons renders multiple radios with value defined by lambda correctly' do
+    collection = [Address.new(id: 1, street: 'Foo'), Address.new(id: 2, street: 'Bar')]
+    expected = %{<div class="form-group"><label class="control-label" for="user_misc">Misc</label><div class="radio"><label for="user_misc_address_1"><input id="user_misc_address_1" name="user[misc]" type="radio" value="address_1" /> Foo</label></div><div class="radio"><label for="user_misc_address_2"><input id="user_misc_address_2" name="user[misc]" type="radio" value="address_2" /> Bar</label></div></div>}
+
+    assert_equal expected, @builder.collection_radio_buttons(:misc, collection, lambda { |a| "address_#{a.id}" }, :street)
+  end
+
 end


### PR DESCRIPTION
Allow :value_method and :text_method for collection_check_boxes and collection_radio_buttons to be any Object that responds to , e.g. a Proc or lambda, to match the same functionality as provided by the corresponding Rails form helper methods.

Ensure that a single String checked value does not perform an include? check by converting checked value(s) to an Array.