### PR TITLE
Fix breaks on non-ActiveRecord setups

### DIFF
--- a/lib/bootstrap_form/form_builder.rb
+++ b/lib/bootstrap_form/form_builder.rb
@@ -264,10 +264,16 @@ module BootstrapForm
 
       target = (obj.class == Class) ? obj : obj.class
       target_validators = target.validators_on(attribute).map(&:class)
-      target_validators.include?(
-        ActiveRecord::Validations::PresenceValidator) || 
-      target_validators.include?(
-        ActiveModel::Validations::PresenceValidator)
+
+      has_presence_validator = target_validators.include?(
+                                 ActiveModel::Validations::PresenceValidator)
+
+      if defined? ActiveRecord::Validations::PresenceValidator
+        has_presence_validator |= target_validators.include?(
+                                    ActiveRecord::Validations::PresenceValidator)
+      end
+
+      has_presence_validator
     end
 
     def form_group_builder(method, options, html_options = nil)


### PR DESCRIPTION
Since ActiveRecord constant is undefined on configs with alternate ORMs,
we first need to check if that value is available before evaluating it.

[bootstrap-ruby/rails-bootstrap-forms#189]