### PR TITLE
Allow label options to be passed in as a hash

### DIFF
--- a/lib/bootstrap_form/form_builder.rb
+++ b/lib/bootstrap_form/form_builder.rb
@@ -309,11 +309,20 @@ module BootstrapForm
       end
 
       unless options.delete(:skip_label)
-        label_class = hide_class if options.delete(:hide_label)
+        if options[:label].is_a?(Hash)
+          label_text  = options[:label].delete(:text)
+          label_class = options[:label].delete(:class)
+          options.delete(:label)
+        end
         label_class ||= options.delete(:label_class)
+        label_class = hide_class if options.delete(:hide_label)
 
-        form_group_options.reverse_merge!(label: {
-          text: options.delete(:label),
+        if options[:label].is_a?(String)
+          label_text ||= options.delete(:label)
+        end
+
+        form_group_options.merge!(label: {
+          text: label_text,
           class: label_class
         })
       end

--- a/test/bootstrap_form_group_test.rb
+++ b/test/bootstrap_form_group_test.rb
@@ -7,9 +7,14 @@ class BootstrapFormGroupTest < ActionView::TestCase
     setup_test_fixture
   end
 
-  test "changing the label text" do
+  test "changing the label text via the label option parameter" do
     expected = %{<div class="form-group"><label class="control-label required" for="user_email">Email Address</label><input class="form-control" id="user_email" name="user[email]" type="text" value="steve@example.com" /></div>}
     assert_equal expected, @builder.text_field(:email, label: 'Email Address')
+  end
+
+  test "changing the label text via the html_options label hash" do
+    expected = %{<div class="form-group"><label class="control-label required" for="user_email">Email Address</label><input class="form-control" id="user_email" name="user[email]" type="text" value="steve@example.com" /></div>}
+    assert_equal expected, @builder.text_field(:email, label: {text: 'Email Address'})
   end
 
   test "hiding a label" do
@@ -17,9 +22,19 @@ class BootstrapFormGroupTest < ActionView::TestCase
     assert_equal expected, @builder.text_field(:email, hide_label: true)
   end
 
-  test "adding a custom label class" do
+  test "adding a custom label class via the label_class parameter" do
     expected = %{<div class="form-group"><label class="btn control-label required" for="user_email">Email</label><input class="form-control" id="user_email" name="user[email]" type="text" value="steve@example.com" /></div>}
     assert_equal expected, @builder.text_field(:email, label_class: 'btn')
+  end
+
+  test "adding a custom label class via the html_options label hash" do
+    expected = %{<div class="form-group"><label class="btn control-label required" for="user_email">Email</label><input class="form-control" id="user_email" name="user[email]" type="text" value="steve@example.com" /></div>}
+    assert_equal expected, @builder.text_field(:email, label: {class: 'btn'})
+  end
+
+  test "adding a custom label and changing the label text via the html_options label hash" do
+    expected = %{<div class="form-group"><label class="btn control-label required" for="user_email">Email Address</label><input class="form-control" id="user_email" name="user[email]" type="text" value="steve@example.com" /></div>}
+    assert_equal expected, @builder.text_field(:email, label: {class: 'btn', text: "Email Address"})
   end
 
   test "skipping a label" do


### PR DESCRIPTION
When generating fields, it should be possible to specify a hash in the
format of `label: { text: "A label", class: "a-class" }`, as indicated
in the documentation.

This approach assumes that if the developer has specified the label as a
hash, then it trumps `label_class` in the options hash.