### PR TITLE
allow to use native collection check_box/radio helpers

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -75,7 +75,7 @@ GEM
       actionpack (>= 3.0)
       activesupport (>= 3.0)
       sprockets (~> 2.8)
-    sqlite3 (1.3.7)
+    sqlite3 (1.3.10)
     thor (0.18.1)
     thread_safe (0.1.0)
       atomic

--- a/lib/bootstrap_form/form_builder.rb
+++ b/lib/bootstrap_form/form_builder.rb
@@ -145,7 +145,7 @@ module BootstrapForm
 
     alias_method_chain :radio_button, :bootstrap
 
-    def collection_check_boxes(*args)
+    def collection_check_boxes_with_bootstrap(*args)
       html = inputs_collection(*args) do |name, value, options|
         options[:multiple] = true
         check_box(name, options, value, nil)
@@ -153,11 +153,15 @@ module BootstrapForm
       hidden_field(args.first,{value: "", multiple: true}).concat(html)
     end
 
-    def collection_radio_buttons(*args)
+    alias_method_chain :collection_check_boxes, :bootstrap
+
+    def collection_radio_buttons_with_bootstrap(*args)
       inputs_collection(*args) do |name, value, options|
         radio_button(name, value, options)
       end
     end
+
+    alias_method_chain :collection_radio_buttons, :bootstrap
 
     def check_boxes_collection(*args)
       warn "'BootstrapForm#check_boxes_collection' is deprecated, use 'BootstrapForm#collection_check_boxes' instead"


### PR DESCRIPTION
Though this gem helpers don't use native collection helpers, they have name collision, so it was impossible to use native helpers with bootstrap form.