### PR TITLE
Add input group option

### DIFF
--- a/lib/bootstrap_form/helpers/bootstrap.rb
+++ b/lib/bootstrap_form/helpers/bootstrap.rb
@@ -65,7 +65,7 @@ module BootstrapForm
 
         input = content_tag(:span, options[:prepend], class: input_group_class(options[:prepend])) + input if options[:prepend]
         input << content_tag(:span, options[:append], class: input_group_class(options[:append])) if options[:append]
-        input = content_tag(:div, input, class: "input-group") unless options.empty?
+        input = content_tag(:div, input, class: (options[:group_class] || "input-group")) unless options.empty?
         input
       end
 

--- a/lib/bootstrap_form/helpers/bootstrap.rb
+++ b/lib/bootstrap_form/helpers/bootstrap.rb
@@ -60,7 +60,7 @@ module BootstrapForm
       end
 
       def prepend_and_append_input(options, &block)
-        options = options.extract!(:prepend, :append)
+        options = options.extract!(:prepend, :append, :group_class)
         input = capture(&block)
 
         input = content_tag(:span, options[:prepend], class: input_group_class(options[:prepend])) + input if options[:prepend]

--- a/test/bootstrap_form_group_test.rb
+++ b/test/bootstrap_form_group_test.rb
@@ -32,6 +32,11 @@ class BootstrapFormGroupTest < ActionView::TestCase
     assert_equal expected, @builder.text_field(:email, prepend: '@')
   end
 
+  test "adding prepend text with custom group class" do
+    expected = %{<div class="form-group"><label class="control-label required" for="user_email">Email</label><div class="input-group input-group-lg"><span class="input-group-addon">@</span><input class="form-control" id="user_email" name="user[email]" type="text" value="steve@example.com" /></div></div>}
+    assert_equal expected, @builder.text_field(:email, prepend: '@', group_class: "input-group input-group-lg")
+  end
+
   test "adding append text" do
     expected = %{<div class="form-group"><label class="control-label required" for="user_email">Email</label><div class="input-group"><input class="form-control" id="user_email" name="user[email]" type="text" value="steve@example.com" /><span class="input-group-addon">.00</span></div></div>}
     assert_equal expected, @builder.text_field(:email, append: '.00')


### PR DESCRIPTION
I'd like to use [input-group-lg](http://getbootstrap.com/components/#input-groups-sizing) on one of my inputs which has appended and prepended items.

I've seen #182 but that approach didn't allow for prepended or appended items that weren't buttons.
