### PR TITLE
Don't rely on Class#name for model naming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 Bugfixes:
 
   - Minor README corrections (#184, @msmithstubbs)
+  - Don't rely on `Class#name` for model naming (#217)
 
 Features:
 

--- a/lib/bootstrap_form/form_builder.rb
+++ b/lib/bootstrap_form/form_builder.rb
@@ -392,15 +392,16 @@ module BootstrapForm
     end
 
     def get_help_text_by_i18n_key(name)
-      underscored_scope = "activerecord.help.#{object.class.name.underscore}"
-      downcased_scope = "activerecord.help.#{object.class.name.downcase}"
-      help_text = I18n.t(name, scope: underscored_scope, default: '').presence
-      help_text ||= if text = I18n.t(name, scope: downcased_scope, default: '').presence
-        warn "I18n key '#{downcased_scope}.#{name}' is deprecated, use '#{underscored_scope}.#{name}' instead"
-        text
+      if object
+        underscored_scope = "activerecord.help.#{object.class.model_name.name.underscore}"
+        downcased_scope = "activerecord.help.#{object.class.model_name.name.downcase}"
+        help_text = I18n.t(name, scope: underscored_scope, default: '').presence
+        help_text ||= if text = I18n.t(name, scope: downcased_scope, default: '').presence
+          warn "I18n key '#{downcased_scope}.#{name}' is deprecated, use '#{underscored_scope}.#{name}' instead"
+          text
+        end
+        help_text
       end
-
-      help_text
     end
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -13,7 +13,12 @@ Rails.backtrace_cleaner.remove_silencers!
 Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].each { |f| require f }
 
 def setup_test_fixture
-  @user = User.new(email: 'steve@example.com', password: 'secret', comments: 'my comment')
+  user_klass = Class.new(User)
+  def user_klass.model_name
+    ActiveModel::Name.new(User)
+  end
+
+  @user = user_klass.new(email: 'steve@example.com', password: 'secret', comments: 'my comment')
   @builder = BootstrapForm::FormBuilder.new(:user, @user, self, {})
   @horizontal_builder = BootstrapForm::FormBuilder.new(:user, @user, self, { layout: :horizontal, label_col: "col-sm-2", control_col: "col-sm-10" })
   I18n.backend.store_translations(:en, {activerecord: {help: {user: {password: "A good password should be at least six characters long"}}}})


### PR DESCRIPTION
Relying on `Class#name` for model naming breaks compatibility with
anonymous models. The `ActiveModel::Naming#model_name` method is
preferred

Also, don’t attempt to get help text for nil objects. This was
previously attempting to lookup `activerecord.help.nil_class.field_name` or similar.