### PR TITLE
Fix a crash when using form for Ransack

### DIFF
--- a/lib/bootstrap_form/form_builder.rb
+++ b/lib/bootstrap_form/form_builder.rb
@@ -267,7 +267,12 @@ module BootstrapForm
       return false unless obj and attribute
 
       target = (obj.class == Class) ? obj : obj.class
-      target_validators = target.validators_on(attribute).map(&:class)
+
+      target_validators = if target.respond_to? :validators_on 
+                            target.validators_on(attribute).map(&:class)
+                          else
+                            []
+                          end
 
       has_presence_validator = target_validators.include?(
                                  ActiveModel::Validations::PresenceValidator)


### PR DESCRIPTION
Fix an issue that causes bootstrap form builder to crash when a field is assigned to a Ransack Search Class, by no longer assuming the object always responds to `on_validators` while figuring out whether the field is required.