### PR TITLE
Allow to pass block to select helper in Rails >= 4.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Bugfixes:
 Features:
 
   - Allow primary button classes to be overridden (#183, @tanimichi)
+  - Allow to pass a block to select helper in Rails >= 4.1.0 (#229, @doits)
 
 ## 2.3.0 (2015-02-17)
 

--- a/lib/bootstrap_form/form_builder.rb
+++ b/lib/bootstrap_form/form_builder.rb
@@ -66,9 +66,17 @@ module BootstrapForm
 
     alias_method_chain :file_field, :bootstrap
 
-    def select_with_bootstrap(method, choices, options = {}, html_options = {})
-      form_group_builder(method, options, html_options) do
-        select_without_bootstrap(method, choices, options, html_options)
+    if Gem::Version.new(Rails::VERSION::STRING) >= Gem::Version.new("4.1.0")
+      def select_with_bootstrap(method, choices = nil, options = {}, html_options = {}, &block)
+        form_group_builder(method, options, html_options) do
+          select_without_bootstrap(method, choices, options, html_options, &block)
+        end
+      end
+    else
+      def select_with_bootstrap(method, choices, options = {}, html_options = {})
+        form_group_builder(method, options, html_options) do
+          select_without_bootstrap(method, choices, options, html_options)
+        end
       end
     end
 

--- a/test/bootstrap_selects_test.rb
+++ b/test/bootstrap_selects_test.rb
@@ -32,6 +32,17 @@ class BootstrapSelectsTest < ActionView::TestCase
     assert_equal expected, @builder.select(:status, [['activated', 1], ['blocked', 2]], { prompt: "Please Select" }, class: "my-select")
   end
 
+  if Gem::Version.new(Rails::VERSION::STRING) >= Gem::Version.new("4.1.0")
+    test "selects with block use block as content" do
+      expected = %{<div class="form-group"><label class="control-label" for="user_status">Status</label><select class="form-control" name="user[status]" id="user_status"><option>Option 1</option><option>Option 2</option></select></div>}
+      select = @builder.select(:status) do
+        content_tag(:option) { 'Option 1' } +
+        content_tag(:option) { 'Option 2' }
+      end
+      assert_equal expected, select
+    end
+  end
+
   test "selects render labels properly" do
     expected = %{<div class="form-group"><label class="control-label" for="user_status">User Status</label><select class="form-control" id="user_status" name="user[status]"><option value="1">activated</option>\n<option value="2">blocked</option></select></div>}
     assert_equal expected, @builder.select(:status, [['activated', 1], ['blocked', 2]], label: "User Status")


### PR DESCRIPTION
Beginning with Rails 4.1.0, the select method allows to pass a block to
render as the options string:

http://apidock.com/rails/v4.1.8/ActionView/Helpers/FormOptionsHelper/select
(the link points to 4.1.8, but it is the same for 4.1.0)

Adapt the gem to allow this.

The test is marked to run on Rails >= 4.1.0 only.

One problem remains though: When updating Rails to 4.1.0 in test
environment, many other tests fail because the order of attributes in
the output changed. I don't know how to solve this yet without rewriting
the expected output for different Rails versions (wich is a cumbersome
task ...).