### PR TITLE
Add tel_field helper

### DIFF
--- a/lib/bootstrap_form/form_builder.rb
+++ b/lib/bootstrap_form/form_builder.rb
@@ -7,7 +7,7 @@ module BootstrapForm
     attr_reader :layout, :label_col, :control_col, :has_error, :inline_errors, :label_errors, :acts_like_form_tag
 
     FIELD_HELPERS = %w{color_field date_field datetime_field datetime_local_field
-      email_field month_field number_field password_field phone_field
+      email_field tel_field month_field number_field password_field phone_field
       range_field search_field telephone_field text_area text_field time_field
       url_field week_field}
 


### PR DESCRIPTION
Adds a helper for input type="tel". Currently only works in Safari but it is a standard HTML form element tag.