### PR TITLE
Fixed use of concat on label and control in order to work with cells

### DIFF
--- a/lib/bootstrap_form/form_builder.rb
+++ b/lib/bootstrap_form/form_builder.rb
@@ -401,6 +401,8 @@ module BootstrapForm
     end
 
     def get_help_text_by_i18n_key(name)
+      return nil if object.class.name.nil?
+
       underscored_scope = "activerecord.help.#{object.class.name.underscore}"
       downcased_scope = "activerecord.help.#{object.class.name.downcase}"
       help_text = I18n.t(name, scope: underscored_scope, default: '').presence

--- a/lib/bootstrap_form/form_builder.rb
+++ b/lib/bootstrap_form/form_builder.rb
@@ -196,7 +196,11 @@ module BootstrapForm
           control = content_tag(:div, control, class: control_class)
         end
 
-        concat(label).concat(control)
+        if label.nil?
+          control
+        else
+          label.concat(control)
+        end
       end
     end
 


### PR DESCRIPTION
I fixed use of concat on label and control in order to work with Cells (https://github.com/apotonick/cells).
In Cells concat returns array instead of string and this code throw error about problem with convert ActiveSupport::SafeBuffer to Array.