### PR TITLE
Allow manual control of label 'required' class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Bugfixes:
 Features:
 
   - Add support for input-group-sm and input-group-lg in prepend/append (#226, @rusanu)
+  - Added option to prevent the 'required' CSS class on labels (#205, @LucasAU)
 
 ## [2.4.0][] (2016-07-04)
 

--- a/README.md
+++ b/README.md
@@ -158,6 +158,12 @@ validator with the associated model attribute. Presently this is one of:
 ActiveRecord::Validations::PresenceValidator or
 ActiveModel::Validations::PresenceValidator.
 
+In cases where this behavior is undesirable, use the `skip_required` option:
+
+```erb
+<%= f.password_field :password, label: "New Password", skip_required: true %>
+```
+
 ### Input Elements / Controls
 
 To specify the class of the generated input, use the `control_class` option:

--- a/lib/bootstrap_form/form_builder.rb
+++ b/lib/bootstrap_form/form_builder.rb
@@ -348,7 +348,8 @@ module BootstrapForm
 
         form_group_options.merge!(label: {
           text: label_text,
-          class: label_class
+          class: label_class,
+          skip_required: options.delete(:skip_required)
         })
       end
 
@@ -367,7 +368,9 @@ module BootstrapForm
       options[:for] = id if acts_like_form_tag
       classes = [options[:class], label_class]
       classes << (custom_label_col || label_col) if get_group_layout(group_layout) == :horizontal
-      classes << "required" if required_attribute?(object, name)
+      unless options.delete(:skip_required)
+        classes << "required" if required_attribute?(object, name)
+      end
 
       options[:class] = classes.compact.join(" ")
 

--- a/test/bootstrap_form_group_test.rb
+++ b/test/bootstrap_form_group_test.rb
@@ -42,6 +42,11 @@ class BootstrapFormGroupTest < ActionView::TestCase
     assert_equal expected, @builder.text_field(:email, skip_label: true)
   end
 
+  test "preventing a label from having the required class" do
+    expected = %{<div class="form-group"><label class="control-label" for="user_email">Email</label><input class="form-control" id="user_email" name="user[email]" type="text" value="steve@example.com" /></div>}
+    assert_equal expected, @builder.text_field(:email, skip_required: true)
+  end
+
   test "adding prepend text" do
     expected = %{<div class="form-group"><label class="control-label required" for="user_email">Email</label><div class="input-group"><span class="input-group-addon">@</span><input class="form-control" id="user_email" name="user[email]" type="text" value="steve@example.com" /></div></div>}
     assert_equal expected, @builder.text_field(:email, prepend: '@')


### PR DESCRIPTION
Added `skip_required` as a field option to prevent the usual checks
for a PresenceValidator and the addition of a 'required' CSS class
to the label element.

This is a fix for #205 and builds on the work done in #143.

(was:)
> Added new field option `label_required` that, if present, will control
> whether the `required` CSS class is added to the label element. If not
> present, continue to use the existing logic that looks for a
> PresenceValidator on the model object.