### PR TITLE
Getting rid of alias_method_chain

### DIFF
--- a/lib/bootstrap_form/form_builder.rb
+++ b/lib/bootstrap_form/form_builder.rb
@@ -31,78 +31,58 @@ module BootstrapForm
     end
 
     FIELD_HELPERS.each do |method_name|
-      with_method_name = "#{method_name}_with_bootstrap"
-      without_method_name = "#{method_name}_without_bootstrap"
-
-      define_method(with_method_name) do |name, options = {}|
+      define_method(method_name) do |name, options = {}|
         form_group_builder(name, options) do
           prepend_and_append_input(options) do
-            send(without_method_name, name, options)
+            super(name, options)
           end
         end
       end
-
-      alias_method_chain method_name, :bootstrap
     end
 
     DATE_SELECT_HELPERS.each do |method_name|
-      with_method_name = "#{method_name}_with_bootstrap"
-      without_method_name = "#{method_name}_without_bootstrap"
-
-      define_method(with_method_name) do |name, options = {}, html_options = {}|
+      define_method(method_name) do |name, options = {}, html_options = {}|
         form_group_builder(name, options, html_options) do
-          content_tag(:div, send(without_method_name, name, options, html_options), class: control_specific_class(method_name))
+          content_tag(:div, super(name, options, html_options), class: control_specific_class(method_name))
         end
       end
-
-      alias_method_chain method_name, :bootstrap
     end
 
-    def file_field_with_bootstrap(name, options = {})
+    def file_field(name, options = {})
       form_group_builder(name, options.reverse_merge(control_class: nil)) do
-        file_field_without_bootstrap(name, options)
+        super(name, options)
       end
     end
 
-    alias_method_chain :file_field, :bootstrap
-
-    def select_with_bootstrap(method, choices, options = {}, html_options = {})
+    def select(method, choices, options = {}, html_options = {})
       form_group_builder(method, options, html_options) do
-        select_without_bootstrap(method, choices, options, html_options)
+        super(method, choices, options, html_options)
       end
     end
 
-    alias_method_chain :select, :bootstrap
-
-    def collection_select_with_bootstrap(method, collection, value_method, text_method, options = {}, html_options = {})
+    def collection_select(method, collection, value_method, text_method, options = {}, html_options = {})
       form_group_builder(method, options, html_options) do
-        collection_select_without_bootstrap(method, collection, value_method, text_method, options, html_options)
+        super(method, collection, value_method, text_method, options, html_options)
       end
     end
 
-    alias_method_chain :collection_select, :bootstrap
-
-    def grouped_collection_select_with_bootstrap(method, collection, group_method, group_label_method, option_key_method, option_value_method, options = {}, html_options = {})
+    def grouped_collection_select(method, collection, group_method, group_label_method, option_key_method, option_value_method, options = {}, html_options = {})
       form_group_builder(method, options, html_options) do
-        grouped_collection_select_without_bootstrap(method, collection, group_method, group_label_method, option_key_method, option_value_method, options, html_options)
+        super(method, collection, group_method, group_label_method, option_key_method, option_value_method, options, html_options)
       end
     end
 
-    alias_method_chain :grouped_collection_select, :bootstrap
-
-    def time_zone_select_with_bootstrap(method, priority_zones = nil, options = {}, html_options = {})
+    def time_zone_select(method, priority_zones = nil, options = {}, html_options = {})
       form_group_builder(method, options, html_options) do
-        time_zone_select_without_bootstrap(method, priority_zones, options, html_options)
+        super(method, priority_zones, options, html_options)
       end
     end
 
-    alias_method_chain :time_zone_select, :bootstrap
-
-    def check_box_with_bootstrap(name, options = {}, checked_value = "1", unchecked_value = "0", &block)
+    def check_box(name, options = {}, checked_value = "1", unchecked_value = "0", &block)
       options = options.symbolize_keys!
       check_box_options = options.except(:label, :label_class, :help, :inline)
 
-      html = check_box_without_bootstrap(name, check_box_options, checked_value, unchecked_value)
+      html = super(name, check_box_options, checked_value, unchecked_value)
       label_content = block_given? ? capture(&block) : options[:label]
       html.concat(" ").concat(label_content || (object && object.class.human_attribute_name(name)) || name.to_s.humanize)
 
@@ -122,13 +102,11 @@ module BootstrapForm
       end
     end
 
-    alias_method_chain :check_box, :bootstrap
-
-    def radio_button_with_bootstrap(name, value, *args)
+    def radio_button(name, value, *args)
       options = args.extract_options!.symbolize_keys!
       args << options.except(:label, :label_class, :help, :inline)
 
-      html = radio_button_without_bootstrap(name, value, *args) + " " + options[:label]
+      html = super(name, value, *args) + " " + options[:label]
 
       disabled_class = " disabled" if options[:disabled]
       label_class    = options[:label_class]
@@ -143,9 +121,7 @@ module BootstrapForm
       end
     end
 
-    alias_method_chain :radio_button, :bootstrap
-
-    def collection_check_boxes_with_bootstrap(*args)
+    def collection_check_boxes(*args)
       html = inputs_collection(*args) do |name, value, options|
         options[:multiple] = true
         check_box(name, options, value, nil)
@@ -153,15 +129,11 @@ module BootstrapForm
       hidden_field(args.first,{value: "", multiple: true}).concat(html)
     end
 
-    alias_method_chain :collection_check_boxes, :bootstrap
-
-    def collection_radio_buttons_with_bootstrap(*args)
+    def collection_radio_buttons(*args)
       inputs_collection(*args) do |name, value, options|
         radio_button(name, value, options)
       end
     end
-
-    alias_method_chain :collection_radio_buttons, :bootstrap
 
     def check_boxes_collection(*args)
       warn "'BootstrapForm#check_boxes_collection' is deprecated, use 'BootstrapForm#collection_check_boxes' instead"
@@ -200,17 +172,15 @@ module BootstrapForm
       end
     end
 
-    def fields_for_with_bootstrap(record_name, record_object = nil, fields_options = {}, &block)
+    def fields_for(record_name, record_object = nil, fields_options = {}, &block)
       fields_options, record_object = record_object, nil if record_object.is_a?(Hash) && record_object.extractable_options?
       fields_options[:layout] ||= options[:layout]
       fields_options[:label_col] = fields_options[:label_col].present? ? "#{fields_options[:label_col]} #{label_class}" : options[:label_col]
       fields_options[:control_col] ||= options[:control_col]
       fields_options[:inline_errors] ||= options[:inline_errors]
       fields_options[:label_errors] ||= options[:label_errors]
-      fields_for_without_bootstrap(record_name, record_object, fields_options, &block)
+      super(record_name, record_object, fields_options, &block)
     end
-
-    alias_method_chain :fields_for, :bootstrap
 
     private
 
@@ -268,7 +238,7 @@ module BootstrapForm
 
       target = (obj.class == Class) ? obj : obj.class
 
-      target_validators = if target.respond_to? :validators_on 
+      target_validators = if target.respond_to? :validators_on
                             target.validators_on(attribute).map(&:class)
                           else
                             []

--- a/test/bootstrap_checkbox_test.rb
+++ b/test/bootstrap_checkbox_test.rb
@@ -3,10 +3,6 @@ require 'test_helper'
 class BootstrapCheckboxTest < ActionView::TestCase
   include BootstrapForm::Helper
 
-  def setup
-    setup_test_fixture
-  end
-
   test "check_box is wrapped correctly" do
     expected = %{<div class="checkbox"><label for="user_terms"><input name="user[terms]" type="hidden" value="0" /><input id="user_terms" name="user[terms]" type="checkbox" value="1" /> I agree to the terms</label></div>}
     assert_equal expected, @builder.check_box(:terms, label: 'I agree to the terms')

--- a/test/bootstrap_fields_test.rb
+++ b/test/bootstrap_fields_test.rb
@@ -3,10 +3,6 @@ require 'test_helper'
 class BootstrapFieldsTest < ActionView::TestCase
   include BootstrapForm::Helper
 
-  def setup
-    setup_test_fixture
-  end
-
   test "color fields are wrapped correctly" do
     expected = %{<div class="form-group"><label class="control-label" for="user_misc">Misc</label><input class="form-control" id="user_misc" name="user[misc]" type="color" value="#000000" /></div>}
     assert_equal expected, @builder.color_field(:misc)

--- a/test/bootstrap_form_group_test.rb
+++ b/test/bootstrap_form_group_test.rb
@@ -3,10 +3,6 @@ require 'test_helper'
 class BootstrapFormGroupTest < ActionView::TestCase
   include BootstrapForm::Helper
 
-  def setup
-    setup_test_fixture
-  end
-
   test "changing the label text via the label option parameter" do
     expected = %{<div class="form-group"><label class="control-label required" for="user_email">Email Address</label><input class="form-control" id="user_email" name="user[email]" type="text" value="steve@example.com" /></div>}
     assert_equal expected, @builder.text_field(:email, label: 'Email Address')
@@ -267,5 +263,5 @@ class BootstrapFormGroupTest < ActionView::TestCase
 
     expected = %{<div class="form-group"><div class="col-sm-9 col-sm-offset-3"><p class="form-control-static">Bar</p></div></div>}
     assert_equal expected, output
-  end    
+  end
 end

--- a/test/bootstrap_form_test.rb
+++ b/test/bootstrap_form_test.rb
@@ -3,10 +3,6 @@ require 'test_helper'
 class BootstrapFormTest < ActionView::TestCase
   include BootstrapForm::Helper
 
-  def setup
-    setup_test_fixture
-  end
-
   test "default-style forms" do
     expected = %{<form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post" role="form"><div style="margin:0;padding:0;display:inline"><input name="utf8" type="hidden" value="&#x2713;" /></div></form>}
     assert_equal expected, bootstrap_form_for(@user) { |f| nil }

--- a/test/bootstrap_other_components_test.rb
+++ b/test/bootstrap_other_components_test.rb
@@ -3,10 +3,6 @@ require 'test_helper'
 class BootstrapOtherComponentsTest < ActionView::TestCase
   include BootstrapForm::Helper
 
-  def setup
-    setup_test_fixture
-  end
-
   test "static control" do
     output = @horizontal_builder.static_control :email
 

--- a/test/bootstrap_radio_button_test.rb
+++ b/test/bootstrap_radio_button_test.rb
@@ -3,10 +3,6 @@ require 'test_helper'
 class BootstrapRadioButtonTest < ActionView::TestCase
   include BootstrapForm::Helper
 
-  def setup
-    setup_test_fixture
-  end
-
   test "radio_button is wrapped correctly" do
     expected = %{<div class="radio"><label for="user_misc_1"><input id="user_misc_1" name="user[misc]" type="radio" value="1" /> This is a radio button</label></div>}
     assert_equal expected, @builder.radio_button(:misc, '1', label: 'This is a radio button')

--- a/test/bootstrap_selects_test.rb
+++ b/test/bootstrap_selects_test.rb
@@ -3,10 +3,6 @@ require 'test_helper'
 class BootstrapSelectsTest < ActionView::TestCase
   include BootstrapForm::Helper
 
-  def setup
-    setup_test_fixture
-  end
-
   test "time zone selects are wrapped correctly" do
     expected = %{<div class="form-group"><label class="control-label" for="user_misc">Misc</label><select class="form-control" id="user_misc" name="user[misc]">#{time_zone_options_for_select}</select></div>}
     assert_equal expected, @builder.time_zone_select(:misc)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -12,9 +12,14 @@ Rails.backtrace_cleaner.remove_silencers!
 # Load support files
 Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].each { |f| require f }
 
-def setup_test_fixture
-  @user = User.new(email: 'steve@example.com', password: 'secret', comments: 'my comment')
-  @builder = BootstrapForm::FormBuilder.new(:user, @user, self, {})
-  @horizontal_builder = BootstrapForm::FormBuilder.new(:user, @user, self, { layout: :horizontal, label_col: "col-sm-2", control_col: "col-sm-10" })
-  I18n.backend.store_translations(:en, {activerecord: {help: {user: {password: "A good password should be at least six characters long"}}}})
+class ActionView::TestCase
+
+  setup :setup_test_fixture
+
+  def setup_test_fixture
+    @user = User.new(email: 'steve@example.com', password: 'secret', comments: 'my comment')
+    @builder = BootstrapForm::FormBuilder.new(:user, @user, self, {})
+    @horizontal_builder = BootstrapForm::FormBuilder.new(:user, @user, self, { layout: :horizontal, label_col: "col-sm-2", control_col: "col-sm-10" })
+    I18n.backend.store_translations(:en, {activerecord: {help: {user: {password: "A good password should be at least six characters long"}}}})
+  end
 end


### PR DESCRIPTION
Heya,

So Rails 5 is coming out eventually, and `alias_method_chain` is not a thing for a very long time now. This PR removes the need for it. Also I moved setup helper method so it's not global.

Cheers. 