### PR TITLE
Mark symbols that are IDs as error when the underlying model has an error

### DIFF
--- a/lib/bootstrap_form/form_builder.rb
+++ b/lib/bootstrap_form/form_builder.rb
@@ -267,7 +267,7 @@ module BootstrapForm
     end
 
     def has_error?(name)
-      object.respond_to?(:errors) && !(name.nil? || object.errors[name].empty?)
+      object.respond_to?(:errors) && !(name.nil? || (object.errors[name].empty? && object.errors[name.to_s.gsub(/_id$/, '')].empty?))
     end
 
     def required_attribute?(obj, attribute)
@@ -387,7 +387,12 @@ module BootstrapForm
     end
 
     def get_error_messages(name)
-      object.errors[name].join(", ")
+      if name.to_s == name.to_s.gsub(/_id$/, '')
+        object.errors[name].join(", ")
+      else
+        error_messages = object.errors[name] + object.errors[name.to_s.gsub(/_id$/, '')]
+        error_messages.join(", ")
+      end
     end
 
     def inputs_collection(name, collection, value, text, options = {}, &block)

--- a/test/bootstrap_form_group_test.rb
+++ b/test/bootstrap_form_group_test.rb
@@ -175,6 +175,18 @@ class BootstrapFormGroupTest < ActionView::TestCase
     assert_equal expected, output
   end
 
+  test 'form_group renders the "error" class when symbol is id' do
+    @user.email = nil
+    @user.valid?
+
+    output = @builder.form_group :email_id do
+      %{<p class="form-control-static">Bar</p>}.html_safe
+    end
+
+    expected = %{<div class="form-group has-error"><p class="form-control-static">Bar</p><span class="help-block">can&#39;t be blank, is too short (minimum is 5 characters)</span></div>}
+    assert_equal expected, output
+  end
+
   test "adds class to wrapped form_group by a field" do
     expected = %{<div class="form-group none-margin"><label class="control-label" for="user_misc">Misc</label><input class="form-control" id="user_misc" name="user[misc]" type="search" /></div>}
     assert_equal expected, @builder.search_field(:misc, wrapper_class: 'none-margin')


### PR DESCRIPTION
With any form field that uses an id (e.g. :role_id) with the underlying validation being on the model it references, errors are not displayed since it doesn't match the symbol on the form. 

This checks both :role and :role_id for errors and uses error messages for both.