### PR TITLE
Sanitize our <label> `for` in accordance with Rails' <input> `id`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 Bugfixes:
 
+  - Sanitize <label> name (IE `for` attribute) in same manner that Rails sanitizes
+    the <input> `id` attribute to fix a11y issue with `for` and `id` mismatch
   - Your contribution here!
 
 Features:

--- a/lib/bootstrap_form/form_builder.rb
+++ b/lib/bootstrap_form/form_builder.rb
@@ -117,7 +117,13 @@ module BootstrapForm
       html.concat(" ").concat(label_content || (object && object.class.human_attribute_name(name)) || name.to_s.humanize)
 
       label_name = name
-      label_name = "#{name}_#{checked_value}" if options[:multiple]
+      # label's `for` attribute needs to match checkbox tag's id,
+      # IE sanitized value, IE
+      # https://github.com/rails/rails/blob/c57e7239a8b82957bcb07534cb7c1a3dcef71864/actionview/lib/action_view/helpers/tags/base.rb#L116-L118
+      if options[:multiple]
+        label_name =
+          "#{name}_#{checked_value.to_s.gsub(/\s/, "_").gsub(/[^-\w]/, "").downcase}"
+      end
 
       disabled_class = " disabled" if options[:disabled]
       label_class    = options[:label_class]

--- a/test/bootstrap_checkbox_test.rb
+++ b/test/bootstrap_checkbox_test.rb
@@ -89,6 +89,13 @@ class BootstrapCheckboxTest < ActionView::TestCase
     assert_equal expected, @builder.collection_check_boxes(:misc, collection, :id, :street, checked: collection)
   end
 
+  test 'collection_check_boxes sanitizes values when generating label `for`' do
+    collection = [Address.new(id: 1, street: 'Foo St')]
+    expected = %{<input id="user_misc" multiple="multiple" name="user[misc][]" type="hidden" value="" /><div class="form-group"><label class="control-label" for="user_misc">Misc</label><div class="checkbox"><label for="user_misc_foo_st"><input id="user_misc_foo_st" name="user[misc][]" type="checkbox" value="Foo St" /> Foo St</label></div></div>}
+
+    assert_equal expected, @builder.collection_check_boxes(:misc, collection, :street, :street)
+  end
+
   test 'collection_check_boxes renders multiple checkboxes with labels defined by Proc :text_method correctly' do
     collection = [Address.new(id: 1, street: 'Foo'), Address.new(id: 2, street: 'Bar')]
     expected = %{<input id="user_misc" multiple="multiple" name="user[misc][]" type="hidden" value="" /><div class="form-group"><label class="control-label" for="user_misc">Misc</label><div class="checkbox"><label for="user_misc_1"><input id="user_misc_1" name="user[misc][]" type="checkbox" value="1" /> ooF</label></div><div class="checkbox"><label for="user_misc_2"><input id="user_misc_2" name="user[misc][]" type="checkbox" value="2" /> raB</label></div></div>}


### PR DESCRIPTION
Fixes mismatching `<label>` `for` and `<input>` `id`.

rails-bootstrap-forms delegates generating the `<input>` `id` to Rails, but generates <label> `for` itself. Because we were not sanitizing the value we use for `<label>` `for`, we get a mismatch between the two, when, for example, the checkbox value has a space in it. This is a a11y problem because browsers do not connect a `<label>` with an inner `<input>` if the label has a `for` that doesn't match the inner `<input>`'s `id`.