### PR TITLE
Fix alias_method_chain deprecation messages in Rails 5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 Bugfixes:
 
   - Minor README corrections (#184, @msmithstubbs)
+  - Fix `alias_method_chain` deprecation warnings when using Rails 5
 
 Features:
 

--- a/lib/bootstrap_form/aliasing.rb
+++ b/lib/bootstrap_form/aliasing.rb
@@ -1,0 +1,35 @@
+module BootstrapForm
+  # This module implements the old ActiveSupport alias_method_chain feature
+  # with a new name, and without the deprecation warnings. In ActiveSupport 5+,
+  # this style of patching was deprecated in favor of Module.prepend. But
+  # Module.prepend is not present in Ruby 1.9, which we would still like to
+  # support. So we continue to use of alias_method_chain, albeit with a
+  # different name to avoid collisions.
+  module Aliasing
+    # This code is copied and pasted from ActiveSupport, but with :bootstrap
+    # hardcoded as the feature name, and with the deprecation warning removed.
+    def bootstrap_method_alias(target)
+      feature = :bootstrap
+
+      # Strip out punctuation on predicates, bang or writer methods since
+      # e.g. target?_without_feature is not a valid method name.
+      aliased_target, punctuation = target.to_s.sub(/([?!=])$/, ''), $1
+      yield(aliased_target, punctuation) if block_given?
+
+      with_method = "#{aliased_target}_with_#{feature}#{punctuation}"
+      without_method = "#{aliased_target}_without_#{feature}#{punctuation}"
+
+      alias_method without_method, target
+      alias_method target, with_method
+
+      case
+      when public_method_defined?(without_method)
+        public target
+      when protected_method_defined?(without_method)
+        protected target
+      when private_method_defined?(without_method)
+        private target
+      end
+    end
+  end
+end

--- a/lib/bootstrap_form/form_builder.rb
+++ b/lib/bootstrap_form/form_builder.rb
@@ -1,7 +1,9 @@
+require_relative 'aliasing'
 require_relative 'helpers/bootstrap'
 
 module BootstrapForm
   class FormBuilder < ActionView::Helpers::FormBuilder
+    extend BootstrapForm::Aliasing
     include BootstrapForm::Helpers::Bootstrap
 
     attr_reader :layout, :label_col, :control_col, :has_error, :inline_errors, :label_errors, :acts_like_form_tag
@@ -42,7 +44,7 @@ module BootstrapForm
         end
       end
 
-      alias_method_chain method_name, :bootstrap
+      bootstrap_method_alias method_name
     end
 
     DATE_SELECT_HELPERS.each do |method_name|
@@ -55,7 +57,7 @@ module BootstrapForm
         end
       end
 
-      alias_method_chain method_name, :bootstrap
+      bootstrap_method_alias method_name
     end
 
     def file_field_with_bootstrap(name, options = {})
@@ -64,7 +66,7 @@ module BootstrapForm
       end
     end
 
-    alias_method_chain :file_field, :bootstrap
+    bootstrap_method_alias :file_field
 
     if Gem::Version.new(Rails::VERSION::STRING) >= Gem::Version.new("4.1.0")
       def select_with_bootstrap(method, choices = nil, options = {}, html_options = {}, &block)
@@ -80,7 +82,7 @@ module BootstrapForm
       end
     end
 
-    alias_method_chain :select, :bootstrap
+    bootstrap_method_alias :select
 
     def collection_select_with_bootstrap(method, collection, value_method, text_method, options = {}, html_options = {})
       form_group_builder(method, options, html_options) do
@@ -88,7 +90,7 @@ module BootstrapForm
       end
     end
 
-    alias_method_chain :collection_select, :bootstrap
+    bootstrap_method_alias :collection_select
 
     def grouped_collection_select_with_bootstrap(method, collection, group_method, group_label_method, option_key_method, option_value_method, options = {}, html_options = {})
       form_group_builder(method, options, html_options) do
@@ -96,7 +98,7 @@ module BootstrapForm
       end
     end
 
-    alias_method_chain :grouped_collection_select, :bootstrap
+    bootstrap_method_alias :grouped_collection_select
 
     def time_zone_select_with_bootstrap(method, priority_zones = nil, options = {}, html_options = {})
       form_group_builder(method, options, html_options) do
@@ -104,7 +106,7 @@ module BootstrapForm
       end
     end
 
-    alias_method_chain :time_zone_select, :bootstrap
+    bootstrap_method_alias :time_zone_select
 
     def check_box_with_bootstrap(name, options = {}, checked_value = "1", unchecked_value = "0", &block)
       options = options.symbolize_keys!
@@ -130,7 +132,7 @@ module BootstrapForm
       end
     end
 
-    alias_method_chain :check_box, :bootstrap
+    bootstrap_method_alias :check_box
 
     def radio_button_with_bootstrap(name, value, *args)
       options = args.extract_options!.symbolize_keys!
@@ -151,7 +153,7 @@ module BootstrapForm
       end
     end
 
-    alias_method_chain :radio_button, :bootstrap
+    bootstrap_method_alias :radio_button
 
     def collection_check_boxes_with_bootstrap(*args)
       html = inputs_collection(*args) do |name, value, options|
@@ -161,7 +163,7 @@ module BootstrapForm
       hidden_field(args.first,{value: "", multiple: true}).concat(html)
     end
 
-    alias_method_chain :collection_check_boxes, :bootstrap
+    bootstrap_method_alias :collection_check_boxes
 
     def collection_radio_buttons_with_bootstrap(*args)
       inputs_collection(*args) do |name, value, options|
@@ -169,7 +171,7 @@ module BootstrapForm
       end
     end
 
-    alias_method_chain :collection_radio_buttons, :bootstrap
+    bootstrap_method_alias :collection_radio_buttons
 
     def check_boxes_collection(*args)
       warn "'BootstrapForm#check_boxes_collection' is deprecated, use 'BootstrapForm#collection_check_boxes' instead"
@@ -218,7 +220,7 @@ module BootstrapForm
       fields_for_without_bootstrap(record_name, record_object, fields_options, &block)
     end
 
-    alias_method_chain :fields_for, :bootstrap
+    bootstrap_method_alias :fields_for
 
     private
 
@@ -276,7 +278,7 @@ module BootstrapForm
 
       target = (obj.class == Class) ? obj : obj.class
 
-      target_validators = if target.respond_to? :validators_on 
+      target_validators = if target.respond_to? :validators_on
                             target.validators_on(attribute).map(&:class)
                           else
                             []


### PR DESCRIPTION
In Rails 5, `alias_method_chain` is deprecated in favor of `Module.prepend`. However, `prepend` is only available in Ruby 2.0+, and we still want to support Ruby 1.9.

Furthermore, the `*_without_bootstrap` aliases that `alias_method_chain` creates are genuinely useful for users of bootstrap_form, because there are some cases where you don't want the Bootstrap-specific markup.

Essentially, we want the traditional `alias_method_chain` behavior, but without the pesky deprecation warnings. This commit reimplements `alias_method_chain` under a new name, `bootstrap_method_alias`. This allows us to keep the behavior the same and avoid the deprecation warnings.

Fixes #253.