### PR TITLE
Prevent mutating (possibly) frozen strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Bugfixes:
 
   - Minor README corrections (#184, @msmithstubbs)
   - Fix `alias_method_chain` deprecation warnings when using Rails 5
+  - Allow `form_group` to work with frozen string options
 
 Features:
 

--- a/lib/bootstrap_form/form_builder.rb
+++ b/lib/bootstrap_form/form_builder.rb
@@ -198,10 +198,10 @@ module BootstrapForm
         control.concat(generate_icon(options[:icon])) if options[:icon]
 
         if get_group_layout(options[:layout]) == :horizontal
-          control_class = (options[:control_col] || control_col.clone)
+          control_class = options[:control_col] || control_col
           unless options[:label]
             control_offset = offset_col(/([0-9]+)$/.match(options[:label_col] || @label_col))
-            control_class.concat(" #{control_offset}")
+            control_class = "#{control_class} #{control_offset}"
           end
           control = content_tag(:div, control, class: control_class)
         end

--- a/test/bootstrap_form_group_test.rb
+++ b/test/bootstrap_form_group_test.rb
@@ -267,5 +267,13 @@ class BootstrapFormGroupTest < ActionView::TestCase
 
     expected = %{<div class="form-group"><div class="col-sm-9 col-sm-offset-3"><p class="form-control-static">Bar</p></div></div>}
     assert_equal expected, output
-  end    
+  end
+
+  test "non-default column span on form isn't mutated" do
+    frozen_horizontal_builder = BootstrapForm::FormBuilder.new(:user, @user, self, { layout: :horizontal, label_col: "col-sm-3".freeze, control_col: "col-sm-9".freeze })
+    output = frozen_horizontal_builder.form_group { 'test' }
+
+    expected = %{<div class="form-group"><div class="col-sm-9 col-sm-offset-3">test</div></div>}
+    assert_equal expected, output
+  end
 end


### PR DESCRIPTION
Currently the `#form_group` method attempts to mutate the
`:control_col` option if no label is supplied. Since this option is
passed by the user, it may be a frozen string literal. Instead, we
simply avoid mutating the supplied string.

As we approach Ruby 3 and frozen string literals become more common,
this is more likely to fail.

*edit: updated changelog.