### PR TITLE
hook include of helper to loading of ActionView

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Bugfixes:
   - Minor README corrections (#184, @msmithstubbs)
   - Fix `alias_method_chain` deprecation warnings when using Rails 5
   - Allow `form_group` to work with frozen string options
+  - Fix loading of ActionView helpers in combination with RSpec and `rails-controller-testing`. (see [rails-controller-testing/issues#24](https://github.com/rails/rails-controller-testing/issues/24))
 
 Features:
 

--- a/lib/bootstrap_form.rb
+++ b/lib/bootstrap_form.rb
@@ -8,4 +8,6 @@ module BootstrapForm
   end
 end
 
-ActionView::Base.send :include, BootstrapForm::Helper
+ActiveSupport.on_load(:action_view) do
+  include BootstrapForm::Helper
+end


### PR DESCRIPTION
this prevents errors with load order of helpers when using rspec for tests.

I also think this should be the way to go for loading extensions.

This is small part of the changes from my previous PR #269 