### PR TITLE
Pin mime-types version for Ruby 1.9 compatibility

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -41,9 +41,7 @@ GEM
     mail (2.6.4)
       mime-types (>= 1.16, < 4)
     metaclass (0.0.4)
-    mime-types (3.1)
-      mime-types-data (~> 3.2015)
-    mime-types-data (3.2016.0521)
+    mime-types (2.6.2)
     minitest (4.7.5)
     mocha (1.1.0)
       metaclass (~> 0.0.1)
@@ -84,6 +82,7 @@ PLATFORMS
 DEPENDENCIES
   bootstrap_form!
   jquery-rails
+  mime-types (~> 2.6.2)
   mocha
   rails (~> 4.0)
   sqlite3

--- a/bootstrap_form.gemspec
+++ b/bootstrap_form.gemspec
@@ -16,6 +16,7 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,db,lib}/**/*"] + ["MIT-LICENSE", "Rakefile", "README.md"]
   s.test_files = Dir["test/**/*"]
 
+  s.add_development_dependency "mime-types", "~> 2.6.2"
   s.add_development_dependency "rails", "~> 4.0"
   s.add_development_dependency "sqlite3"
   s.add_development_dependency "timecop", "~> 0.7.1"


### PR DESCRIPTION
This should fix a bundler error in the Travis build.