### PR TITLE
Use ActiveSupport.on_load looks to inject behavior into ActionView::Base

### DIFF
--- a/lib/bootstrap_form.rb
+++ b/lib/bootstrap_form.rb
@@ -8,4 +8,6 @@ module BootstrapForm
   end
 end
 
-ActionView::Base.send :include, BootstrapForm::Helper
+ActiveSupport.on_load(:action_view) do
+  include BootstrapForm::Helper
+end


### PR DESCRIPTION
Use `ActiveSupport.on_load` was strongly suggested in https://github.com/rails/rails-controller-testing/issues/24#issuecomment-231738446.  I'm hoping it will begin resolving Rails 5 testing failures in my application.