### PR TITLE
Don't rely on Class#name for model naming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [Pending Release][]
 
 Bugfixes:
+  - Fix getting help text for elements when using anonymous models (see [issue 282](https://github.com/bootstrap-ruby/rails-bootstrap-forms/issues/282))
   - Your contribution here!
 
 Features:

--- a/lib/bootstrap_form/form_builder.rb
+++ b/lib/bootstrap_form/form_builder.rb
@@ -425,15 +425,21 @@ module BootstrapForm
     end
 
     def get_help_text_by_i18n_key(name)
-      underscored_scope = "activerecord.help.#{object.class.name.underscore}"
-      downcased_scope = "activerecord.help.#{object.class.name.downcase}"
-      help_text = I18n.t(name, scope: underscored_scope, default: '').presence
-      help_text ||= if text = I18n.t(name, scope: downcased_scope, default: '').presence
-        warn "I18n key '#{downcased_scope}.#{name}' is deprecated, use '#{underscored_scope}.#{name}' instead"
-        text
-      end
+       if object
 
-      help_text
+         # ActiveModel::Naming 3.X.X does not support .name; it is supported as of 4.X.X
+        partial_scope = object.class.model_name.respond_to?(:name) ? object.class.model_name.name : object.class.model_name
+
+        underscored_scope = "activerecord.help.#{partial_scope.underscore}"
+        downcased_scope = "activerecord.help.#{partial_scope.downcase}"
+        help_text = I18n.t(name, scope: underscored_scope, default: '').presence
+        help_text ||= if text = I18n.t(name, scope: downcased_scope, default: '').presence
+                        warn "I18n key '#{downcased_scope}.#{name}' is deprecated, use '#{underscored_scope}.#{name}' instead"
+                        text
+                      end
+        help_text
+       end
     end
+
   end
 end

--- a/test/special_form_class_models_test.rb
+++ b/test/special_form_class_models_test.rb
@@ -1,0 +1,32 @@
+require 'test_helper'
+
+class SpecialFormClassModelsTest < ActionView::TestCase
+  include BootstrapForm::Helper
+
+  test "Anonymous models are supported for form builder" do
+    user_klass = Class.new(User)
+    def user_klass.model_name
+      ActiveModel::Name.new(User)
+    end
+
+    @user = user_klass.new(email: 'steve@example.com', password: 'secret', comments: 'my comment')
+    @builder = BootstrapForm::FormBuilder.new(:user, @user, self, {})
+    @horizontal_builder = BootstrapForm::FormBuilder.new(:user, @user, self, {layout: :horizontal, label_col: "col-sm-2", control_col: "col-sm-10"})
+    I18n.backend.store_translations(:en, {activerecord: {help: {user: {password: "A good password should be at least six characters long"}}}})
+
+    expected = %{<div class="form-group"><label class="control-label" for="user_misc">Misc</label><input class="form-control" id="user_misc" name="user[misc]" type="date" /></div>}
+    assert_equal expected, @builder.date_field(:misc)
+  end
+
+
+  test "Nil models are supported for form builder" do
+    @user = nil
+    @builder = BootstrapForm::FormBuilder.new(:user, @user, self, {})
+    @horizontal_builder = BootstrapForm::FormBuilder.new(:user, @user, self, {layout: :horizontal, label_col: "col-sm-2", control_col: "col-sm-10"})
+    I18n.backend.store_translations(:en, {activerecord: {help: {user: {password: "A good password should be at least six characters long"}}}})
+
+    expected = %{<div class="form-group"><label class="control-label" for="user_misc">Misc</label><input class="form-control" id="user_misc" name="user[misc]" type="date" /></div>}
+    assert_equal expected, @builder.date_field(:misc)
+  end
+
+end


### PR DESCRIPTION
taken from https://github.com/bootstrap-ruby/rails-bootstrap-forms/pull/217 (@boffbowsh)

Relying on Class#name for model naming breaks compatibility with
anonymous models. The ActiveModel::Naming#model_name method is
preferred

Also, don’t attempt to get help text for nil objects. This was
previously attempting to lookup activerecord.help.nil_class.field_name or similar.