### PR TITLE
add custom_control

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Bugfixes:
 
 Features:
   - Your contribution here!
+  - Add a FormBuilder#custom_control helper [#289](https://github.com/bootstrap-ruby/rails-bootstrap-forms/pull/289)
 
 ## [2.5.0][] (2016-08-12)
 

--- a/lib/bootstrap_form/helpers/bootstrap.rb
+++ b/lib/bootstrap_form/helpers/bootstrap.rb
@@ -63,9 +63,7 @@ module BootstrapForm
         options = args.extract_options!
         name = args.first
 
-        form_group_builder(name, options) do
-          capture(&block)
-        end
+        form_group_builder(name, options, &block)
       end
 
       def prepend_and_append_input(options, &block)

--- a/lib/bootstrap_form/helpers/bootstrap.rb
+++ b/lib/bootstrap_form/helpers/bootstrap.rb
@@ -59,6 +59,15 @@ module BootstrapForm
         end
       end
 
+      def custom_control(*args, &block)
+        options = args.extract_options!
+        name = args.first
+
+        form_group_builder(name, options) do
+          capture(&block)
+        end
+      end
+
       def prepend_and_append_input(options, &block)
         options = options.extract!(:prepend, :append, :input_group_class)
         input_group_class = ["input-group", options[:input_group_class]].compact.join(' ')

--- a/test/bootstrap_other_components_test.rb
+++ b/test/bootstrap_other_components_test.rb
@@ -32,6 +32,33 @@ class BootstrapOtherComponentsTest < ActionView::TestCase
     assert_equal expected, output
   end
 
+  test "custom control does't wrap given block in a p tag" do
+    output = @horizontal_builder.custom_control :email do
+      "this is a test"
+    end
+
+    expected = %{<div class="form-group"><label class="control-label col-sm-2 required" for="user_email">Email</label><div class="col-sm-10">this is a test</div></div>}
+    assert_equal expected, output
+  end
+
+  test "custom control doesn't require an actual attribute" do
+    output = @horizontal_builder.custom_control nil, label: "My Label" do
+      "this is a test"
+    end
+
+    expected = %{<div class="form-group"><label class="control-label col-sm-2" for="user_">My Label</label><div class="col-sm-10">this is a test</div></div>}
+    assert_equal expected, output
+  end
+
+  test "custom control doesn't require a name" do
+    output = @horizontal_builder.custom_control label: "Custom Label" do
+      "Custom Control"
+    end
+
+    expected = %{<div class="form-group"><label class="control-label col-sm-2" for="user_">Custom Label</label><div class="col-sm-10">Custom Control</div></div>}
+    assert_equal expected, output
+  end
+
   test "submit button defaults to rails action name" do
     expected = %{<input class="btn btn-default" name="commit" type="submit" value="Create User" />}
     assert_equal expected, @builder.submit


### PR DESCRIPTION
`static_control` wraps the displayed value in a `p` tag.
This is a problem in some edge use case, when you want to display an `ul` element.
It leads to invalid HTML generation that is silently changed by erb / haml / slim.

This view (slim) :

```
= f.static_control(:my_attribute) do
  ul
    li abc
    li def
```

Generate something like :

```
...
<p></p>
<ul><li>abc</li><li>def</li><ul>
<p></p>
...
```

The new `custom_control` helper generates expected view :

```
...
<p>
<ul><li>abc</li><li>def</li><ul>
</p>
...
```
