### PR TITLE
Use `File.exist?` instead of `File.exists?`

### DIFF
--- a/test/dummy/config/boot.rb
+++ b/test/dummy/config/boot.rb
@@ -1,4 +1,4 @@
 # Set up gems listed in the Gemfile.
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../Gemfile', __FILE__)
 
-require 'bundler/setup' if File.exists?(ENV['BUNDLE_GEMFILE'])
+require 'bundler/setup' if File.exist?(ENV['BUNDLE_GEMFILE'])


### PR DESCRIPTION
To suppress the following warning from Ruby:
```
warning: File.exists? is a deprecated name, use File.exist? instead
```

`File.exist?` is defined in current supported Ruby versions.