### PR TITLE
Fix offset_col to match label with for non-sm column classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 Bugfixes:
   - Allow objects without `model_name`s to act as form objects (#295, @laserlemon)
+  - Fix offset for submit for horizontal forms when using non-sm column breakers for label column (#293, @oteyatosys)
   - Your contribution here!
 
 Features:

--- a/lib/bootstrap_form/form_builder.rb
+++ b/lib/bootstrap_form/form_builder.rb
@@ -206,7 +206,7 @@ module BootstrapForm
         if get_group_layout(options[:layout]) == :horizontal
           control_class = options[:control_col] || control_col
           unless options[:label]
-            control_offset = offset_col(/([0-9]+)$/.match(options[:label_col] || @label_col))
+            control_offset = offset_col(options[:label_col] || @label_col)
             control_class = "#{control_class} #{control_offset}"
           end
           control = content_tag(:div, control, class: control_class)
@@ -242,8 +242,8 @@ module BootstrapForm
       "col-sm-2"
     end
 
-    def offset_col(offset)
-      "col-sm-offset-#{offset}"
+    def offset_col(label_col)
+      label_col.sub(/^col-(\w+)-(\d)$/, 'col-\1-offset-\2')
     end
 
     def default_control_col

--- a/test/bootstrap_form_test.rb
+++ b/test/bootstrap_form_test.rb
@@ -146,6 +146,11 @@ class BootstrapFormTest < ActionView::TestCase
     assert_equal expected, bootstrap_form_for(@user, layout: :horizontal) { |f| f.email_field :email, label_col: 'col-sm-1' }
   end
 
+  test "offset for form group without label respects label width for horizontal forms" do
+    expected = %{<form accept-charset="UTF-8" action="/users" class="form-horizontal" id="new_user" method="post" role="form"><div style="margin:0;padding:0;display:inline"><input name="utf8" type="hidden" value="&#x2713;" /></div><div class="form-group"><div class="col-md-10 col-md-offset-2"><input class="btn btn-default" name="commit" type="submit" value="Create User" /></div></div></form>}
+    assert_equal expected, bootstrap_form_for(@user, layout: :horizontal, label_col: 'col-md-2', control_col: 'col-md-10') { |f| f.form_group { f.submit } }
+  end
+
   test "custom input width for horizontal forms" do
     expected = %{<form accept-charset="UTF-8" action="/users" class="form-horizontal" id="new_user" method="post" role="form"><div style="margin:0;padding:0;display:inline"><input name="utf8" type="hidden" value="&#x2713;" /></div><div class="form-group"><label class="control-label col-sm-2 required" for="user_email">Email</label><div class="col-sm-5"><input class="form-control" id="user_email" name="user[email]" type="email" value="steve@example.com" /></div></div></form>}
     assert_equal expected, bootstrap_form_for(@user, layout: :horizontal) { |f| f.email_field :email, control_col: 'col-sm-5' }


### PR DESCRIPTION
When building horizontal forms with a label_col other than col-sm-*, the offset would be calculated incorrectly. I changed the method offset_col to take other column breakers into account.