### PR TITLE
Support form objects that lack model names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [Pending Release][]
 
 Bugfixes:
+  - Allow objects without `model_name`s to act as form objects (#295, @laserlemon)
   - Your contribution here!
 
 Features:

--- a/lib/bootstrap_form/form_builder.rb
+++ b/lib/bootstrap_form/form_builder.rb
@@ -425,9 +425,9 @@ module BootstrapForm
     end
 
     def get_help_text_by_i18n_key(name)
-       if object
+      if object
 
-         # ActiveModel::Naming 3.X.X does not support .name; it is supported as of 4.X.X
+        # ActiveModel::Naming 3.X.X does not support .name; it is supported as of 4.X.X
         partial_scope = object.class.model_name.respond_to?(:name) ? object.class.model_name.name : object.class.model_name
 
         underscored_scope = "activerecord.help.#{partial_scope.underscore}"
@@ -438,7 +438,7 @@ module BootstrapForm
                         text
                       end
         help_text
-       end
+      end
     end
 
   end

--- a/lib/bootstrap_form/form_builder.rb
+++ b/lib/bootstrap_form/form_builder.rb
@@ -427,8 +427,12 @@ module BootstrapForm
     def get_help_text_by_i18n_key(name)
       if object
 
-        # ActiveModel::Naming 3.X.X does not support .name; it is supported as of 4.X.X
-        partial_scope = object.class.model_name.respond_to?(:name) ? object.class.model_name.name : object.class.model_name
+        if object.class.respond_to?(:model_name)
+          # ActiveModel::Naming 3.X.X does not support .name; it is supported as of 4.X.X
+          partial_scope = object.class.model_name.respond_to?(:name) ? object.class.model_name.name : object.class.model_name
+        else
+          partial_scope = object.class.name
+        end
 
         underscored_scope = "activerecord.help.#{partial_scope.underscore}"
         downcased_scope = "activerecord.help.#{partial_scope.downcase}"

--- a/test/dummy/app/models/faux_user.rb
+++ b/test/dummy/app/models/faux_user.rb
@@ -1,0 +1,9 @@
+class FauxUser
+  attr_accessor :email, :password, :comments, :misc
+
+  def initialize(attributes = {})
+    attributes.each do |name, value|
+      send("#{name}=", value)
+    end
+  end
+end

--- a/test/special_form_class_models_test.rb
+++ b/test/special_form_class_models_test.rb
@@ -18,12 +18,23 @@ class SpecialFormClassModelsTest < ActionView::TestCase
     assert_equal expected, @builder.date_field(:misc)
   end
 
-
   test "Nil models are supported for form builder" do
     @user = nil
     @builder = BootstrapForm::FormBuilder.new(:user, @user, self, {})
     @horizontal_builder = BootstrapForm::FormBuilder.new(:user, @user, self, {layout: :horizontal, label_col: "col-sm-2", control_col: "col-sm-10"})
     I18n.backend.store_translations(:en, {activerecord: {help: {user: {password: "A good password should be at least six characters long"}}}})
+
+    expected = %{<div class="form-group"><label class="control-label" for="user_misc">Misc</label><input class="form-control" id="user_misc" name="user[misc]" type="date" /></div>}
+    assert_equal expected, @builder.date_field(:misc)
+  end
+
+  test "Objects without model names are supported for form builder" do
+    user_klass = FauxUser
+
+    @user = user_klass.new(email: 'steve@example.com', password: 'secret', comments: 'my comment')
+    @builder = BootstrapForm::FormBuilder.new(:user, @user, self, {})
+    @horizontal_builder = BootstrapForm::FormBuilder.new(:user, @user, self, {layout: :horizontal, label_col: "col-sm-2", control_col: "col-sm-10"})
+    I18n.backend.store_translations(:en, {activerecord: {help: {faux_user: {password: "A good password should be at least six characters long"}}}})
 
     expected = %{<div class="form-group"><label class="control-label" for="user_misc">Misc</label><input class="form-control" id="user_misc" name="user[misc]" type="date" /></div>}
     assert_equal expected, @builder.date_field(:misc)


### PR DESCRIPTION
This is useful in using Bootstrap Forms with third party libraries such as Ransack, whose queries and values do not always conform fully to the Active Model API.

A class's name, while model_name is preferred, is still a good fallback.