### PR TITLE
Support :prepend and :append for the `select` helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ Bugfixes:
 
 Features:
   - Your contribution here!
+  * [#325](https://github.com/bootstrap-ruby/rails-bootstrap-forms/pull/325): Support :prepend and :append for the `select` helper - [@donv](https://github.com/donv).
+
 
 ## [2.6.0][] (2017-02-03)
 

--- a/lib/bootstrap_form/form_builder.rb
+++ b/lib/bootstrap_form/form_builder.rb
@@ -71,13 +71,17 @@ module BootstrapForm
     if Gem::Version.new(Rails::VERSION::STRING) >= Gem::Version.new("4.1.0")
       def select_with_bootstrap(method, choices = nil, options = {}, html_options = {}, &block)
         form_group_builder(method, options, html_options) do
-          select_without_bootstrap(method, choices, options, html_options, &block)
+          prepend_and_append_input(options) do
+            select_without_bootstrap(method, choices, options, html_options, &block)
+          end
         end
       end
     else
       def select_with_bootstrap(method, choices, options = {}, html_options = {})
         form_group_builder(method, options, html_options) do
-          select_without_bootstrap(method, choices, options, html_options)
+          prepend_and_append_input(options) do
+            select_without_bootstrap(method, choices, options, html_options)
+          end
         end
       end
     end

--- a/test/bootstrap_selects_test.rb
+++ b/test/bootstrap_selects_test.rb
@@ -35,7 +35,7 @@ class BootstrapSelectsTest < ActionView::TestCase
   test 'selects with addons are wrapped correctly' do
     expected = <<-HTML.strip_heredoc
       <div class="form-group">
-        <label class="control-label" for="user_status">Status</label>
+        <label class="form-control-label" for="user_status">Status</label>
         <div class="input-group">
           <span class="input-group-addon">Before</span>
           <select class="form-control" id="user_status" name="user[status]">

--- a/test/bootstrap_selects_test.rb
+++ b/test/bootstrap_selects_test.rb
@@ -32,6 +32,23 @@ class BootstrapSelectsTest < ActionView::TestCase
     assert_equivalent_xml expected, @builder.select(:status, [['activated', 1], ['blocked', 2]], { prompt: "Please Select" }, class: "my-select")
   end
 
+  test 'selects with addons are wrapped correctly' do
+    expected = <<-HTML.strip_heredoc
+      <div class="form-group">
+        <label class="control-label" for="user_status">Status</label>
+        <div class="input-group">
+          <span class="input-group-addon">Before</span>
+          <select class="form-control" id="user_status" name="user[status]">
+            <option value="1">activated</option>
+            <option value="2">blocked</option>
+          </select>
+          <span class="input-group-addon">After</span>
+        </div>
+      </div>
+    HTML
+    assert_equivalent_xml expected, @builder.select(:status, [['activated', 1], ['blocked', 2]], prepend: 'Before', append: 'After')
+  end
+
   if Gem::Version.new(Rails::VERSION::STRING) >= Gem::Version.new("4.1.0")
     test "selects with block use block as content" do
       expected = %{<div class="form-group"><label class="form-control-label" for="user_status">Status</label><select class="form-control" name="user[status]" id="user_status"><option>Option 1</option><option>Option 2</option></select></div>}


### PR DESCRIPTION
Fixes #147 for Bootstrap 4