### PR TITLE
add 5.1, use more explicit version definition for existing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,27 +10,18 @@ gemfile:
   - gemfiles/4.0.gemfile
   - gemfiles/4.1.gemfile
   - gemfiles/4.2.gemfile
-  - gemfiles/5.0.gemfile
-  - gemfiles/5.1.gemfile
 matrix:
-  exclude:
-    - rvm: 1.9
-      gemfile: gemfiles/5.0.gemfile
-    - rvm: 2.0
-      gemfile: gemfiles/5.0.gemfile
-    - rvm: 2.1
-      gemfile: gemfiles/5.0.gemfile
-    - rvm: 1.9
-      gemfile: gemfiles/5.1.gemfile
-    - rvm: 2.0
-      gemfile: gemfiles/5.1.gemfile
-    - rvm: 2.1
-      gemfile: gemfiles/5.1.gemfile
   include:
-    # Run Danger only once
+    - rvm: 2.2.2
+      gemfile: gemfiles/5.0.gemfile
     - rvm: 2.3.1
       gemfile: gemfiles/5.0.gemfile
+      # Run Danger only once
       script: bundle exec danger
+    - rvm: 2.2.2
+      gemfile: gemfiles/5.1.gemfile
+    - rvm: 2.3.1
+      gemfile: gemfiles/5.1.gemfile
   allow_failures:
     - gemfile: gemfiles/5.1.gemfile
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ gemfile:
   - gemfiles/4.1.gemfile
   - gemfiles/4.2.gemfile
   - gemfiles/5.0.gemfile
+  - gemfiles/5.1.gemfile
 matrix:
   exclude:
     - rvm: 1.9
@@ -19,6 +20,12 @@ matrix:
       gemfile: gemfiles/5.0.gemfile
     - rvm: 2.1
       gemfile: gemfiles/5.0.gemfile
+    - rvm: 1.9
+      gemfile: gemfiles/5.1.gemfile
+    - rvm: 2.0
+      gemfile: gemfiles/5.1.gemfile
+    - rvm: 2.1
+      gemfile: gemfiles/5.1.gemfile
   include:
     # Run Danger only once
     - rvm: 2.3.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,8 @@ matrix:
     - rvm: 2.3.1
       gemfile: gemfiles/5.0.gemfile
       script: bundle exec danger
+  allow_failures:
+    - gemfile: gemfiles/5.1.gemfile
 before_install:
   - gem install bundler --conservative --version '~> 1.10'
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,8 +22,6 @@ matrix:
       gemfile: gemfiles/5.1.gemfile
     - rvm: 2.3.1
       gemfile: gemfiles/5.1.gemfile
-  allow_failures:
-    - gemfile: gemfiles/5.1.gemfile
 before_install:
   - gem install bundler --conservative --version '~> 1.10'
 before_script:

--- a/Appraisals
+++ b/Appraisals
@@ -1,19 +1,26 @@
 appraise "4.0" do
   gem "rails", "~> 4.0.0"
-  gemspec
+  # nokogiri 1.7+ is not compatible with Ruby < 2.1, so pin at older version.
+  gem "nokogiri", "~> 1.6.8", platforms: [:ruby_19, :ruby_20]
 end
 
 appraise "4.1" do
   gem "rails", "~> 4.1.0"
-  gemspec
+  # nokogiri 1.7+ is not compatible with Ruby < 2.1, so pin at older version.
+  gem "nokogiri", "~> 1.6.8", platforms: [:ruby_19, :ruby_20]
 end
 
 appraise "4.2" do
-  gem "rails", "~> 4.2"
-  gemspec
+  gem "rails", "~> 4.2.0"
+  # nokogiri 1.7+ is not compatible with Ruby < 2.1, so pin at older version.
+  gem "nokogiri", "~> 1.6.8", platforms: [:ruby_19, :ruby_20]
 end
 
 appraise "5.0" do
-  gem "rails", "~> 5.0"
-  gemspec
+  gem "rails", "~> 5.0.0"
+  gem "danger"
+end
+
+appraise "5.1" do
+  gem "rails", "~> 5.1.0"
 end

--- a/Appraisals
+++ b/Appraisals
@@ -18,6 +18,7 @@ end
 
 appraise "5.0" do
   gem "rails", "~> 5.0.0"
+  gem "minitest", "< 5.10.2"
   gem "danger"
 end
 

--- a/Appraisals
+++ b/Appraisals
@@ -23,4 +23,5 @@ end
 
 appraise "5.1" do
   gem "rails", "~> 5.1.0"
+  gem "minitest", "< 5.10.2"
 end

--- a/gemfiles/4.0.gemfile
+++ b/gemfiles/4.0.gemfile
@@ -4,8 +4,6 @@ source "http://rubygems.org"
 
 gem "jquery-rails"
 gem "rails", "~> 4.0.0"
+gem "nokogiri", "~> 1.6.8", platforms: [:ruby_19, :ruby_20]
 
-# nokogiri 1.7+ is not compatible with Ruby < 2.1, so pin at older version.
-gem "nokogiri", "~> 1.6.8" if RUBY_VERSION =~ /^(1\.9|2\.0)\./
-
-gemspec :path => "../"
+gemspec path: "../"

--- a/gemfiles/4.1.gemfile
+++ b/gemfiles/4.1.gemfile
@@ -4,8 +4,6 @@ source "http://rubygems.org"
 
 gem "jquery-rails"
 gem "rails", "~> 4.1.0"
+gem "nokogiri", "~> 1.6.8", platforms: [:ruby_19, :ruby_20]
 
-# nokogiri 1.7+ is not compatible with Ruby < 2.1, so pin at older version.
-gem "nokogiri", "~> 1.6.8" if RUBY_VERSION =~ /^(1\.9|2\.0)\./
-
-gemspec :path => "../"
+gemspec path: "../"

--- a/gemfiles/4.2.gemfile
+++ b/gemfiles/4.2.gemfile
@@ -3,7 +3,7 @@
 source "http://rubygems.org"
 
 gem "jquery-rails"
-gem "rails", "~> 4.2"
+gem "rails", "~> 4.2.0"
 
 # nokogiri 1.7+ is not compatible with Ruby < 2.1, so pin at older version.
 gem "nokogiri", "~> 1.6.8" if RUBY_VERSION =~ /^(1\.9|2\.0)\./

--- a/gemfiles/4.2.gemfile
+++ b/gemfiles/4.2.gemfile
@@ -4,8 +4,6 @@ source "http://rubygems.org"
 
 gem "jquery-rails"
 gem "rails", "~> 4.2.0"
+gem "nokogiri", "~> 1.6.8", platforms: [:ruby_19, :ruby_20]
 
-# nokogiri 1.7+ is not compatible with Ruby < 2.1, so pin at older version.
-gem "nokogiri", "~> 1.6.8" if RUBY_VERSION =~ /^(1\.9|2\.0)\./
-
-gemspec :path => "../"
+gemspec path: "../"

--- a/gemfiles/5.0.gemfile
+++ b/gemfiles/5.0.gemfile
@@ -4,6 +4,7 @@ source "http://rubygems.org"
 
 gem "jquery-rails"
 gem "rails", "~> 5.0.0"
+gem "minitest", "< 5.10.2"
 gem "danger"
 
 gemspec path: "../"

--- a/gemfiles/5.0.gemfile
+++ b/gemfiles/5.0.gemfile
@@ -6,4 +6,4 @@ gem "jquery-rails"
 gem "rails", "~> 5.0.0"
 gem "danger"
 
-gemspec :path => "../"
+gemspec path: "../"

--- a/gemfiles/5.1.gemfile
+++ b/gemfiles/5.1.gemfile
@@ -5,4 +5,4 @@ source "http://rubygems.org"
 gem "jquery-rails"
 gem "rails", "~> 5.1.0"
 
-gemspec :path => "../"
+gemspec path: "../"

--- a/gemfiles/5.1.gemfile
+++ b/gemfiles/5.1.gemfile
@@ -3,7 +3,6 @@
 source "http://rubygems.org"
 
 gem "jquery-rails"
-gem "rails", "~> 5.0.0"
-gem "danger"
+gem "rails", "~> 5.1.0"
 
 gemspec :path => "../"

--- a/gemfiles/5.1.gemfile
+++ b/gemfiles/5.1.gemfile
@@ -4,5 +4,6 @@ source "http://rubygems.org"
 
 gem "jquery-rails"
 gem "rails", "~> 5.1.0"
+gem "minitest", "< 5.10.2"
 
 gemspec path: "../"

--- a/test/bootstrap_form_test.rb
+++ b/test/bootstrap_form_test.rb
@@ -43,7 +43,12 @@ class BootstrapFormTest < ActionView::TestCase
   end
 
   test "bootstrap_form_tag allows an empty name for checkboxes" do
-    expected = %{<form accept-charset="UTF-8" action="/users" method="post" role="form"><div style="margin:0;padding:0;display:inline"><input name="utf8" type="hidden" value="&#x2713;" /></div><div class="checkbox"><label for="_misc"><input name="[misc]" type="hidden" value="0" /><input id="_misc" name="[misc]" type="checkbox" value="1" /> Misc</label></div></form>}
+    checkbox = if ::Rails::VERSION::STRING >= '5.1'
+      %{<div class="checkbox"><label for="misc"><input name="misc" type="hidden" value="0" /><input id="misc" name="misc" type="checkbox" value="1" /> Misc</label></div>}
+    else
+      %{<div class="checkbox"><label for="_misc"><input name="[misc]" type="hidden" value="0" /><input id="_misc" name="[misc]" type="checkbox" value="1" /> Misc</label></div>}
+    end
+    expected = %{<form accept-charset="UTF-8" action="/users" method="post" role="form"><div style="margin:0;padding:0;display:inline"><input name="utf8" type="hidden" value="&#x2713;" /></div>#{checkbox}</form>}
     assert_equivalent_xml expected, bootstrap_form_tag(url: '/users') { |f| f.check_box :misc }
   end
 

--- a/test/dummy/config/initializers/generic_migration.rb
+++ b/test/dummy/config/initializers/generic_migration.rb
@@ -1,0 +1,6 @@
+version = Rails.version.to_f
+if version < 5.0
+  class GenericMigration < ActiveRecord::Migration; end
+else
+  class GenericMigration < ActiveRecord::Migration[5.0]; end
+end

--- a/test/dummy/db/migrate/20130703191909_create_users.rb
+++ b/test/dummy/db/migrate/20130703191909_create_users.rb
@@ -1,4 +1,4 @@
-class CreateUsers < ActiveRecord::Migration
+class CreateUsers < ActiveRecord::Migration[4.2]
   def change
     create_table :users do |t|
       t.string :email

--- a/test/dummy/db/migrate/20130703191909_create_users.rb
+++ b/test/dummy/db/migrate/20130703191909_create_users.rb
@@ -1,4 +1,4 @@
-class CreateUsers < ActiveRecord::Migration[4.2]
+class CreateUsers < GenericMigration
   def change
     create_table :users do |t|
       t.string :email

--- a/test/dummy/db/migrate/20130703191937_create_addresses.rb
+++ b/test/dummy/db/migrate/20130703191937_create_addresses.rb
@@ -1,4 +1,4 @@
-class CreateAddresses < ActiveRecord::Migration
+class CreateAddresses < ActiveRecord::Migration[4.2]
   def change
     create_table :addresses do |t|
       t.integer :user_id

--- a/test/dummy/db/migrate/20130703191937_create_addresses.rb
+++ b/test/dummy/db/migrate/20130703191937_create_addresses.rb
@@ -1,4 +1,4 @@
-class CreateAddresses < ActiveRecord::Migration[4.2]
+class CreateAddresses < GenericMigration
   def change
     create_table :addresses do |t|
       t.integer :user_id

--- a/test/dummy/db/migrate/20130912171202_add_preferences_to_user.rb
+++ b/test/dummy/db/migrate/20130912171202_add_preferences_to_user.rb
@@ -1,4 +1,4 @@
-class AddPreferencesToUser < ActiveRecord::Migration[4.2]
+class AddPreferencesToUser < GenericMigration
   def change
     add_column :users, :preferences, :text
   end

--- a/test/dummy/db/migrate/20130912171202_add_preferences_to_user.rb
+++ b/test/dummy/db/migrate/20130912171202_add_preferences_to_user.rb
@@ -1,4 +1,4 @@
-class AddPreferencesToUser < ActiveRecord::Migration
+class AddPreferencesToUser < ActiveRecord::Migration[4.2]
   def change
     add_column :users, :preferences, :text
   end

--- a/test/dummy/db/migrate/20140327190145_add_terms_to_user.rb
+++ b/test/dummy/db/migrate/20140327190145_add_terms_to_user.rb
@@ -1,4 +1,4 @@
-class AddTermsToUser < ActiveRecord::Migration
+class AddTermsToUser < ActiveRecord::Migration[4.2]
   def change
     add_column :users, :terms, :boolean, default: false
   end

--- a/test/dummy/db/migrate/20140327190145_add_terms_to_user.rb
+++ b/test/dummy/db/migrate/20140327190145_add_terms_to_user.rb
@@ -1,4 +1,4 @@
-class AddTermsToUser < ActiveRecord::Migration[4.2]
+class AddTermsToUser < GenericMigration
   def change
     add_column :users, :terms, :boolean, default: false
   end

--- a/test/dummy/db/migrate/20140922133133_add_type_to_users.rb
+++ b/test/dummy/db/migrate/20140922133133_add_type_to_users.rb
@@ -1,4 +1,4 @@
-class AddTypeToUsers < ActiveRecord::Migration
+class AddTypeToUsers < ActiveRecord::Migration[4.2]
   def change
     add_column :users, :type, :string
   end

--- a/test/dummy/db/migrate/20140922133133_add_type_to_users.rb
+++ b/test/dummy/db/migrate/20140922133133_add_type_to_users.rb
@@ -1,4 +1,4 @@
-class AddTypeToUsers < ActiveRecord::Migration[4.2]
+class AddTypeToUsers < GenericMigration
   def change
     add_column :users, :type, :string
   end

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -1,4 +1,3 @@
-# encoding: UTF-8
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -13,27 +12,27 @@
 
 ActiveRecord::Schema.define(version: 20140922133133) do
 
-  create_table "addresses", force: true do |t|
-    t.integer  "user_id"
-    t.string   "street"
-    t.string   "city"
-    t.string   "state"
-    t.string   "zip_code"
+  create_table "addresses", force: :cascade do |t|
+    t.integer "user_id"
+    t.string "street"
+    t.string "city"
+    t.string "state"
+    t.string "zip_code"
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
-  create_table "users", force: true do |t|
-    t.string   "email"
-    t.string   "password"
-    t.text     "comments"
-    t.string   "status"
-    t.string   "misc"
+  create_table "users", force: :cascade do |t|
+    t.string "email"
+    t.string "password"
+    t.text "comments"
+    t.string "status"
+    t.string "misc"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.text     "preferences"
-    t.boolean  "terms",       default: false
-    t.string   "type"
+    t.text "preferences"
+    t.boolean "terms", default: false
+    t.string "type"
   end
 
 end


### PR DESCRIPTION
The start of fixing #329

defining a gem as `~> 5.0` would allow bundler to install `5.1`, which is not what we want, and made the build fail all of a sudden. So I updated it to use more explicit version definitions.

Also added 5.1, which is still failing, but that will be step 2.