### PR TITLE
let travis use container builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: false
 language: ruby
 rvm:
   - 1.9


### PR DESCRIPTION
by disabling sudo we allow travis to run the build in a container environment, which is expected to be much quicker.