### PR TITLE
Fix issue that would result in an error when the output buffer doesn't respond to concat().

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,15 @@
 ## [Pending Release][]
 
 Bugfixes:
-  - Fix an issue that occurs when the output buffer of the calling template is based on a type other than a String (i.e. an Array).
+  - Your contribution here!
 
 Features:
   - Your contribution here!
+  
+## [Pending Release][]
+  
+Bugfixes:
+  - Fix an issue that occurs when the output buffer of the calling template is based on a type other than a String (i.e. an Array).
 
 ## [2.7.0][] (2017-04-21)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## [Pending Release][]
 
 Bugfixes:
-  - Your contribution here!
+  - Fix an issue that occurs when the output buffer of the calling template is based on a type other than a String (i.e. an Array).
 
 Features:
   - Your contribution here!

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ Features:
 ## [Pending Release][]
   
 Bugfixes:
-  - Fix an issue that occurs when the output buffer of the calling template is based on a type other than a String (i.e. an Array).
+  - Fix an issue that occurs when the output buffer of the view layer does not respond to "concat" (i.e. an Array).
 
 ## [2.7.0][] (2017-04-21)
 

--- a/lib/bootstrap_form/form_builder.rb
+++ b/lib/bootstrap_form/form_builder.rb
@@ -216,7 +216,8 @@ module BootstrapForm
           control = content_tag(:div, control, class: control_class)
         end
 
-        concat(label).concat(control)
+        concat(label)
+        concat(control)
       end
     end
 


### PR DESCRIPTION
Hello,

I did not create an issue ticket for this.  When I started looking into it, I wasn't sure where the problem was.  The edit is pretty simple.

I am using a non-standard view layer [Trailblazer Cells](http://trailblazer.to/gems/cells/) in a Rails environment.  In certain situations when using this gem, I would get 'No implicit conversion from Array into String' errors.  I traced the error back to where I made the change.  By chaining the concat() calls together, it relies on concat() to return the correct object.  By not chaining the calls together, both calls are handled the same way and the dependency is removed.  
