### PR TITLE
fix typo on select usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,7 +261,7 @@ You still can use `wrapper_class` option to set only a css class. This is just a
 Our select helper accepts the same arguments as the [default Rails helper](http://api.rubyonrails.org/classes/ActionView/Helpers/FormOptionsHelper.html#method-i-select). Here's an example of how you pass both options and html_options hashes:
 
 ```erb
-<%= f.select :product, [[1, "Apple"], [2, "Grape"]], { label: "Choose your favorite fruit:" }, { class: "selectpicker" } %>
+<%= f.select :product, [["Apple", 1], ["Grape", 2]], { label: "Choose your favorite fruit:" }, { class: "selectpicker" } %>
 ```
 
 ### Checkboxes and Radios


### PR DESCRIPTION
Fixing error reported on https://github.com/bootstrap-ruby/rails-bootstrap-forms/issues/351