### PR TITLE
Clarify Bootstrap v3 support in 2.7.x README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,27 @@
-[![Build Status](https://travis-ci.org/bootstrap-ruby/rails-bootstrap-forms.svg?branch=master)](https://travis-ci.org/bootstrap-ruby/rails-bootstrap-forms)
-[![Gem Version](https://badge.fury.io/rb/bootstrap_form.svg)](http://badge.fury.io/rb/bootstrap_form)
+⚠️ **This documentation refers to bootstrap_form 2.7.x, which supports Bootstrap v3.** If you are using Bootstrap v4, refer to the [master](https://github.com/bootstrap-ruby/rails-bootstrap-forms/) branch.
 
-# Rails Bootstrap Forms
+---
 
-**Rails Bootstrap Forms** is a rails form builder that makes it super easy to integrate
-twitter bootstrap-style forms into your rails application.
+# bootstrap_form
+
+[![Build Status](https://travis-ci.org/bootstrap-ruby/rails-bootstrap-forms.svg?branch=legacy-2.7)](https://travis-ci.org/bootstrap-ruby/rails-bootstrap-forms)
+
+**bootstrap_form** is a Rails form builder that makes it super easy to integrate
+Bootstrap v3-style forms into your Rails application.
 
 ## Requirements
 
 * Ruby 1.9+
 * Rails 4.0+
-* Twitter Bootstrap 3.0+
+* Twitter Bootstrap 3.x
 
 ## Installation
 
 Add it to your Gemfile:
 
-`gem 'bootstrap_form'`
+```ruby
+gem "bootstrap_form", "~> 2.7"
+```
 
 Then:
 
@@ -589,4 +594,4 @@ document first.
 
 ## License
 
-MIT License. Copyright 2012-2014 Stephen Potenza (https://github.com/potenza)
+MIT License. Copyright 2012-2018 Stephen Potenza (https://github.com/potenza)


### PR DESCRIPTION
The `legacy-2.7` branch supports Bootstrap v3, not v4. Add a prominent message to make that clear.