### PR TITLE
Fix Bootstrap v4.0.0-beta.3 breaking change with input group addons

### DIFF
--- a/lib/bootstrap_form/helpers/bootstrap.rb
+++ b/lib/bootstrap_form/helpers/bootstrap.rb
@@ -72,18 +72,15 @@ module BootstrapForm
 
         input = capture(&block)
 
-        input = content_tag(:span, options[:prepend], class: input_group_class(options[:prepend])) + input if options[:prepend]
-        input << content_tag(:span, options[:append], class: input_group_class(options[:append])) if options[:append]
+        input = content_tag(:div, input_group_content(options[:prepend]), class: 'input-group-prepend') + input if options[:prepend]
+        input << content_tag(:div, input_group_content(options[:append]), class: 'input-group-append') if options[:append]
         input = content_tag(:div, input, class: input_group_class) unless options.empty?
         input
       end
 
-      def input_group_class(add_on_content)
-        if add_on_content.match(/btn/)
-          'input-group-btn'
-        else
-          'input-group-addon'
-        end
+      def input_group_content(content)
+        return content if content.match(/btn/)
+        content_tag(:span, content, class: 'input-group-text')
       end
 
       def static_class

--- a/test/bootstrap_form_group_test.rb
+++ b/test/bootstrap_form_group_test.rb
@@ -48,23 +48,24 @@ class BootstrapFormGroupTest < ActionView::TestCase
   end
 
   test "adding prepend text" do
-    expected = %{<div class="form-group"><label class="form-control-label required" for="user_email">Email</label><div class="input-group"><span class="input-group-addon">@</span><input class="form-control" id="user_email" name="user[email]" type="text" value="steve@example.com" /></div></div>}
+    expected = %{<div class="form-group"><label class="form-control-label required" for="user_email">Email</label><div class="input-group"><div class="input-group-prepend"><span class="input-group-text">@</span></div><input class="form-control" id="user_email" name="user[email]" type="text" value="steve@example.com" /></div></div>}
     assert_equivalent_xml expected, @builder.text_field(:email, prepend: '@')
   end
 
   test "adding append text" do
-    expected = %{<div class="form-group"><label class="form-control-label required" for="user_email">Email</label><div class="input-group"><input class="form-control" id="user_email" name="user[email]" type="text" value="steve@example.com" /><span class="input-group-addon">.00</span></div></div>}
+    expected = %{<div class="form-group"><label class="form-control-label required" for="user_email">Email</label><div class="input-group"><input class="form-control" id="user_email" name="user[email]" type="text" value="steve@example.com" /><div class="input-group-append"><span class="input-group-text">.00</span></div></div></div>}
     assert_equivalent_xml expected, @builder.text_field(:email, append: '.00')
   end
 
   test "append and prepend button" do
     prefix = %{<div class="form-group"><label class="form-control-label required" for="user_email">Email</label><div class="input-group">}
     field = %{<input class="form-control" id="user_email" name="user[email]" type="text" value="steve@example.com" />}
-    button = %{<span class="input-group-btn"><a class="btn btn-secondary" href="#">Click</a></span>}
+    button_prepend = %{<div class="input-group-prepend"><a class="btn btn-secondary" href="#">Click</a></div>}
+    button_append = %{<div class="input-group-append"><a class="btn btn-secondary" href="#">Click</a></div>}
     suffix = %{</div></div>}
-    after_button = prefix + field + button + suffix
-    before_button = prefix + button + field + suffix
-    both_button = prefix + button + field + button  + suffix
+    after_button = prefix + field + button_append + suffix
+    before_button = prefix + button_prepend + field + suffix
+    both_button = prefix + button_prepend + field + button_append  + suffix
     button_src = link_to("Click", "#", class: "btn btn-secondary")
     assert_equivalent_xml after_button, @builder.text_field(:email, append: button_src)
     assert_equivalent_xml before_button, @builder.text_field(:email, prepend: button_src)
@@ -72,7 +73,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
   end
 
   test "adding both prepend and append text" do
-    expected = %{<div class="form-group"><label class="form-control-label required" for="user_email">Email</label><div class="input-group"><span class="input-group-addon">$</span><input class="form-control" id="user_email" name="user[email]" type="text" value="steve@example.com" /><span class="input-group-addon">.00</span></div></div>}
+    expected = %{<div class="form-group"><label class="form-control-label required" for="user_email">Email</label><div class="input-group"><div class="input-group-prepend"><span class="input-group-text">$</div></div><input class="form-control" id="user_email" name="user[email]" type="text" value="steve@example.com" /><div class="input-group-append"><span class="input-group-text">.00</span></div></div></div>}
     assert_equivalent_xml expected, @builder.text_field(:email, prepend: '$', append: '.00')
   end
 
@@ -283,7 +284,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
   end
 
   test ":input_group_class should apply to input-group" do
-    expected = %{<div class="form-group"><label class="form-control-label required" for="user_email">Email</label><div class="input-group input-group-lg"><input class="form-control" id="user_email" name="user[email]" type="email" value="steve@example.com" /><span class="input-group-btn"><input class="btn btn-primary" name="commit" type="submit" value="Subscribe" /></span></div></div>}
+    expected = %{<div class="form-group"><label class="form-control-label required" for="user_email">Email</label><div class="input-group input-group-lg"><input class="form-control" id="user_email" name="user[email]" type="email" value="steve@example.com" /><div class="input-group-append"><input class="btn btn-primary" name="commit" type="submit" value="Subscribe" /></div></div></div>}
     assert_equivalent_xml expected, @builder.email_field(:email, append: @builder.primary('Subscribe'), input_group_class: 'input-group-lg')
   end
 end

--- a/test/bootstrap_selects_test.rb
+++ b/test/bootstrap_selects_test.rb
@@ -37,12 +37,12 @@ class BootstrapSelectsTest < ActionView::TestCase
       <div class="form-group">
         <label class="form-control-label" for="user_status">Status</label>
         <div class="input-group">
-          <span class="input-group-addon">Before</span>
+          <div class="input-group-prepend"><span class="input-group-text">Before</span></div>
           <select class="form-control" id="user_status" name="user[status]">
             <option value="1">activated</option>
             <option value="2">blocked</option>
           </select>
-          <span class="input-group-addon">After</span>
+          <div class="input-group-append"><span class="input-group-text">After</span></div>
         </div>
       </div>
     HTML


### PR DESCRIPTION
Beta 3 introduced a breaking change with how input group addons
are used with prepend and append. Details can be found here in
their migration docs:

https://getbootstrap.com/docs/4.0/migration/#input-groups