### PR TITLE
Pin Minitest to work around crash on test failure.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,3 +16,5 @@ group :test do
   gem "sqlite3"
   gem "timecop", "~> 0.7.1"
 end
+
+gem "minitest", "~> 5.10.3"


### PR DESCRIPTION
Minitest 5.11 is broken for environments, like Rails, that use custom reporters. Pin to 5.10.3 in the meantime.

Addresses issue #371.