### PR TITLE
Putting minitest dependency in the right place. Fixing PR#372

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,11 +10,12 @@ group :development do
 end
 
 group :test do
+  # can relax version requirement for Rails 5.2.beta3+
+  gem "minitest", "~> 5.10.3"
+
   gem "diffy"
   gem "equivalent-xml"
   gem "mocha"
   gem "sqlite3"
   gem "timecop", "~> 0.7.1"
 end
-
-gem "minitest", "~> 5.10.3"

--- a/test/gemfiles/5.0.gemfile
+++ b/test/gemfiles/5.0.gemfile
@@ -5,10 +5,10 @@ gemspec path: "../../"
 gem "rails", "~> 5.0.0"
 
 group :test do
+  gem "minitest", "~> 5.10.3"
   gem "diffy"
   gem "equivalent-xml"
   gem "mocha"
   gem "sqlite3"
   gem "timecop", "~> 0.7.1"
 end
-

--- a/test/gemfiles/5.1.gemfile
+++ b/test/gemfiles/5.1.gemfile
@@ -5,6 +5,7 @@ gemspec path: "../../"
 gem "rails", "~> 5.1.0"
 
 group :test do
+  gem "minitest", "~> 5.10.3"
   gem "diffy"
   gem "equivalent-xml"
   gem "mocha"

--- a/test/gemfiles/5.2.gemfile
+++ b/test/gemfiles/5.2.gemfile
@@ -5,6 +5,9 @@ gemspec path: "../../"
 gem "rails", "~> 5.2.0.beta2"
 
 group :test do
+  # can relax version requirement for Rails 5.2.beta3+
+  gem "minitest", "~> 5.10.3"
+
   gem "diffy"
   gem "equivalent-xml"
   gem "mocha"


### PR DESCRIPTION
test gemspecs for rails < 5.2 will have it pinned permanently