### PR TITLE
[v4] Removing glyphicon option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ Bugfixes:
   - Your contribution here!
   - form-control-danger is replaced with is-invalid for bootstrap 4.0.0.beta3
   - form-control-feedback is replaced with invalid-feedback for bootstrap 4.0.0.beta3
-  - help texts are rendered with <small> tag instead of <span> tag, i.e. like in bootstrap 4.0.0.beta3 
+  - help texts are rendered with <small> tag instead of <span> tag, i.e. like in bootstrap 4.0.0.beta3
+  - `icon` option is no longer available
 
 Features:
   - Your contribution here!

--- a/README.md
+++ b/README.md
@@ -206,32 +206,13 @@ en:
     help:
       user:
         password_html: "A <strong>good</strong> password should be at least six characters long"
-``` 
+```
 
 If your model name has multiple words (like `SuperUser`), the key on the
 translation file should be underscored (`super_user`).
 
 You can override help translations for a particular field by passing the `help`
 option or turn them off completely by passing `help: false`.
-
-### Icons
-
-To add an icon to a field, use the `icon` option and pass the icon name
-*without* the 'glyphicon' prefix:
-
-```erb
-<%= f.text_field :login, icon: "user" %>
-```
-
-This automatically adds the `has-feedback` class to the `form-group`:
-
-```html
-<div class="form-group has-feedback">
-  <label class="form-control-label" for="user_login">Login</label>
-  <input class="form-control" id="user_login" name="user[login]" type="text" />
-  <span class="glyphicon glyphicon-user form-control-feedback"></span>
-</div>
-```
 
 ### Prepending and Appending Inputs
 

--- a/lib/bootstrap_form/form_builder.rb
+++ b/lib/bootstrap_form/form_builder.rb
@@ -149,7 +149,7 @@ module BootstrapForm
         content_tag(:div, class: div_class.compact.join(" ")) do
           checkbox_html.concat(label(label_name, html, class: ["custom-control-label", label_class].compact.join(" ")))
         end
-      else 
+      else
         disabled_class = " disabled" if options[:disabled]
         if options[:inline]
           label_class = " #{label_class}" if label_class
@@ -185,7 +185,7 @@ module BootstrapForm
         content_tag(:div, class: div_class.compact.join(" ")) do
           radio_html.concat(label(name, html, value: value, class: ["custom-control-label", label_class].compact.join(" ")))
         end
-      else 
+      else
         if options[:inline]
           label_class = " #{label_class}" if label_class
           label(name, html, class: "radio-inline#{disabled_class}#{label_class}", value: value)
@@ -239,7 +239,6 @@ module BootstrapForm
         label = generate_label(options[:id], name, options[:label], options[:label_col], options[:layout]) if options[:label]
         control = capture(&block).to_s
         control.concat(generate_help(name, options[:help]).to_s)
-        control.concat(generate_icon(options[:icon])) if options[:icon]
 
         if get_group_layout(options[:layout]) == :horizontal
           control_class = options[:control_col] || control_col
@@ -428,10 +427,6 @@ module BootstrapForm
       help_tag ||= :small
 
       content_tag(help_tag, help_text, class: help_klass) if help_text.present?
-    end
-
-    def generate_icon(icon)
-      content_tag(:span, "", class: "glyphicon glyphicon-#{icon} invalid-feedback")
     end
 
     def get_error_messages(name)

--- a/test/bootstrap_form_group_test.rb
+++ b/test/bootstrap_form_group_test.rb
@@ -399,17 +399,6 @@ class BootstrapFormGroupTest < ActionView::TestCase
     assert_equivalent_xml expected, output
   end
 
-  test "adding an icon to a field" do
-    expected = <<-HTML.strip_heredoc
-      <div class="form-group has-feedback">
-        <label class="" for="user_misc">Misc</label>
-        <input class="form-control" id="user_misc" name="user[misc]" type="email" />
-        <span class="glyphicon glyphicon-ok invalid-feedback"></span>
-      </div>
-    HTML
-    assert_equivalent_xml expected, @builder.email_field(:misc, icon: 'ok')
-  end
-
   test "single form_group call in horizontal form should not be smash design" do
     output = ''
     output = @horizontal_builder.form_group do


### PR DESCRIPTION
Glyphicons are not part of Bootstrap4 and markup generated is not a thing anymore.