### PR TITLE
[v4] Fix file input class

### DIFF
--- a/lib/bootstrap_form/form_builder.rb
+++ b/lib/bootstrap_form/form_builder.rb
@@ -61,7 +61,8 @@ module BootstrapForm
     end
 
     def file_field_with_bootstrap(name, options = {})
-      form_group_builder(name, options.reverse_merge(control_class: nil)) do
+      options = options.reverse_merge(control_class: 'form-control-file')
+      form_group_builder(name, options) do
         file_field_without_bootstrap(name, options)
       end
     end

--- a/test/bootstrap_fields_test.rb
+++ b/test/bootstrap_fields_test.rb
@@ -59,7 +59,7 @@ class BootstrapFieldsTest < ActionView::TestCase
     expected = <<-HTML.strip_heredoc
       <div class="form-group">
         <label for="user_misc">Misc</label>
-        <input id="user_misc" name="user[misc]" type="file" />
+        <input class="form-control-file" id="user_misc" name="user[misc]" type="file" />
       </div>
     HTML
     assert_equivalent_xml expected, @builder.file_field(:misc)


### PR DESCRIPTION
Latest (beta3) version of bootstrap 4 requires file input to have `form-control-file` class. This PR adds this class.