### PR TITLE
Don't add class="" to label if no classes specified.

### DIFF
--- a/lib/bootstrap_form/form_builder.rb
+++ b/lib/bootstrap_form/form_builder.rb
@@ -149,7 +149,7 @@ module BootstrapForm
         content_tag(:div, class: div_class.compact.join(" ")) do
           checkbox_html.concat(label(label_name, html, class: ["custom-control-label", label_class].compact.join(" ")))
         end
-      else 
+      else
         disabled_class = " disabled" if options[:disabled]
         if options[:inline]
           label_class = " #{label_class}" if label_class
@@ -185,7 +185,7 @@ module BootstrapForm
         content_tag(:div, class: div_class.compact.join(" ")) do
           radio_html.concat(label(name, html, value: value, class: ["custom-control-label", label_class].compact.join(" ")))
         end
-      else 
+      else
         if options[:inline]
           label_class = " #{label_class}" if label_class
           label(name, html, class: "radio-inline#{disabled_class}#{label_class}", value: value)
@@ -403,7 +403,8 @@ module BootstrapForm
         classes << "required" if required_attribute?(object, name)
       end
 
-      options[:class] = classes.compact.join(" ")
+      options[:class] = classes.compact.join(" ").strip
+      options.delete(:class) if options[:class].empty?
 
       if label_errors && has_error?(name)
         error_messages = get_error_messages(name)

--- a/test/bootstrap_fields_test.rb
+++ b/test/bootstrap_fields_test.rb
@@ -8,7 +8,7 @@ class BootstrapFieldsTest < ActionView::TestCase
   test "color fields are wrapped correctly" do
     expected = <<-HTML.strip_heredoc
       <div class="form-group">
-        <label class="" for="user_misc">Misc</label>
+        <label for="user_misc">Misc</label>
         <input class="form-control" id="user_misc" name="user[misc]" type="color" value="#000000" />
       </div>
     HTML
@@ -18,7 +18,7 @@ class BootstrapFieldsTest < ActionView::TestCase
   test "date fields are wrapped correctly" do
     expected = <<-HTML.strip_heredoc
       <div class="form-group">
-        <label class="" for="user_misc">Misc</label>
+        <label for="user_misc">Misc</label>
         <input class="form-control" id="user_misc" name="user[misc]" type="date" />
       </div>
     HTML
@@ -28,7 +28,7 @@ class BootstrapFieldsTest < ActionView::TestCase
   test "date time fields are wrapped correctly" do
     expected = <<-HTML.strip_heredoc
       <div class="form-group">
-        <label class="" for="user_misc">Misc</label>
+        <label for="user_misc">Misc</label>
         <input class="form-control" id="user_misc" name="user[misc]" type="datetime" />
       </div>
     HTML
@@ -38,7 +38,7 @@ class BootstrapFieldsTest < ActionView::TestCase
   test "date time local fields are wrapped correctly" do
     expected = <<-HTML.strip_heredoc
       <div class="form-group">
-        <label class="" for="user_misc">Misc</label>
+        <label for="user_misc">Misc</label>
         <input class="form-control" id="user_misc" name="user[misc]" type="datetime-local" />
       </div>
     HTML
@@ -48,7 +48,7 @@ class BootstrapFieldsTest < ActionView::TestCase
   test "email fields are wrapped correctly" do
     expected = <<-HTML.strip_heredoc
       <div class="form-group">
-        <label class="" for="user_misc">Misc</label>
+        <label for="user_misc">Misc</label>
         <input class="form-control" id="user_misc" name="user[misc]" type="email" />
       </div>
     HTML
@@ -58,7 +58,7 @@ class BootstrapFieldsTest < ActionView::TestCase
   test "file fields are wrapped correctly" do
     expected = <<-HTML.strip_heredoc
       <div class="form-group">
-        <label class="" for="user_misc">Misc</label>
+        <label for="user_misc">Misc</label>
         <input id="user_misc" name="user[misc]" type="file" />
       </div>
     HTML
@@ -73,7 +73,7 @@ class BootstrapFieldsTest < ActionView::TestCase
   test "month local fields are wrapped correctly" do
     expected = <<-HTML.strip_heredoc
       <div class="form-group">
-        <label class="" for="user_misc">Misc</label>
+        <label for="user_misc">Misc</label>
         <input class="form-control" id="user_misc" name="user[misc]" type="month" />
       </div>
     HTML
@@ -83,7 +83,7 @@ class BootstrapFieldsTest < ActionView::TestCase
   test "number fields are wrapped correctly" do
     expected = <<-HTML.strip_heredoc
       <div class="form-group">
-        <label class="" for="user_misc">Misc</label>
+        <label for="user_misc">Misc</label>
         <input class="form-control" id="user_misc" name="user[misc]" type="number" />
       </div>
     HTML
@@ -93,7 +93,7 @@ class BootstrapFieldsTest < ActionView::TestCase
   test "password fields are wrapped correctly" do
     expected = <<-HTML.strip_heredoc
       <div class="form-group">
-        <label class="" for="user_password">Password</label>
+        <label for="user_password">Password</label>
         <input class="form-control" id="user_password" name="user[password]" type="password" />
         <small class="form-text text-muted">A good password should be at least six characters long</small>
       </div>
@@ -104,7 +104,7 @@ class BootstrapFieldsTest < ActionView::TestCase
   test "phone/telephone fields are wrapped correctly" do
     expected = <<-HTML.strip_heredoc
       <div class="form-group">
-        <label class="" for="user_misc">Misc</label>
+        <label for="user_misc">Misc</label>
         <input class="form-control" id="user_misc" name="user[misc]" type="tel" />
       </div>
     HTML
@@ -115,7 +115,7 @@ class BootstrapFieldsTest < ActionView::TestCase
   test "range fields are wrapped correctly" do
     expected = <<-HTML.strip_heredoc
       <div class="form-group">
-        <label class="" for="user_misc">Misc</label>
+        <label for="user_misc">Misc</label>
         <input class="form-control" id="user_misc" name="user[misc]" type="range" />
       </div>
     HTML
@@ -125,7 +125,7 @@ class BootstrapFieldsTest < ActionView::TestCase
   test "search fields are wrapped correctly" do
     expected = <<-HTML.strip_heredoc
       <div class="form-group">
-        <label class="" for="user_misc">Misc</label>
+        <label for="user_misc">Misc</label>
         <input class="form-control" id="user_misc" name="user[misc]" type="search" />
       </div>
     HTML
@@ -135,7 +135,7 @@ class BootstrapFieldsTest < ActionView::TestCase
   test "text areas are wrapped correctly" do
     expected = <<-HTML.strip_heredoc
       <div class="form-group">
-        <label class="" for="user_comments">Comments</label>
+        <label for="user_comments">Comments</label>
         <textarea class="form-control" id="user_comments" name="user[comments]">\nmy comment</textarea>
       </div>
     HTML
@@ -155,7 +155,7 @@ class BootstrapFieldsTest < ActionView::TestCase
   test "time fields are wrapped correctly" do
     expected = <<-HTML.strip_heredoc
       <div class="form-group">
-        <label class="" for="user_misc">Misc</label>
+        <label for="user_misc">Misc</label>
         <input class="form-control" id="user_misc" name="user[misc]" type="time" />
       </div>
     HTML
@@ -165,7 +165,7 @@ class BootstrapFieldsTest < ActionView::TestCase
   test "url fields are wrapped correctly" do
     expected = <<-HTML.strip_heredoc
       <div class="form-group">
-        <label class="" for="user_misc">Misc</label>
+        <label for="user_misc">Misc</label>
         <input class="form-control" id="user_misc" name="user[misc]" type="url" />
       </div>
     HTML
@@ -175,7 +175,7 @@ class BootstrapFieldsTest < ActionView::TestCase
   test "week fields are wrapped correctly" do
     expected = <<-HTML.strip_heredoc
       <div class="form-group">
-        <label class="" for="user_misc">Misc</label>
+        <label for="user_misc">Misc</label>
         <input class="form-control" id="user_misc" name="user[misc]" type="week" />
       </div>
     HTML
@@ -195,7 +195,7 @@ class BootstrapFieldsTest < ActionView::TestCase
       <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post" role="form">
         <input name="utf8" type="hidden" value="&#x2713;" />
         <div class="form-group">
-          <label class="" for="user_address_attributes_street">Street</label>
+          <label for="user_address_attributes_street">Street</label>
           <input class="form-control" id="user_address_attributes_street" name="user[address_attributes][street]" type="text" value="123 Main Street" />
         </div>
       </form>
@@ -216,7 +216,7 @@ class BootstrapFieldsTest < ActionView::TestCase
       <form accept-charset="UTF-8" action="/users" class="new_user" id="new_user" method="post" role="form">
         <input name="utf8" type="hidden" value="&#x2713;" />
         <div class="form-group">
-          <label class="" for="user_preferences_favorite_color">Favorite color</label>
+          <label for="user_preferences_favorite_color">Favorite color</label>
           <input class="form-control" id="user_preferences_favorite_color" name="user[preferences][favorite_color]" type="text" value="cerulean" />
         </div>
       </form>
@@ -260,7 +260,7 @@ class BootstrapFieldsTest < ActionView::TestCase
       <form accept-charset="UTF-8" action="/users" class="form-inline" id="new_user" method="post" role="form">
         <input name="utf8" type="hidden" value="&#x2713;" />
         <div class="form-group">
-          <label class="" for="user_address_attributes_street">Street</label>
+          <label for="user_address_attributes_street">Street</label>
           <input class="form-control" id="user_address_attributes_street" name="user[address_attributes][street]" type="text" value="123 Main Street" />
         </div>
       </form>

--- a/test/bootstrap_form_group_test.rb
+++ b/test/bootstrap_form_group_test.rb
@@ -77,7 +77,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
   test "preventing a label from having the required class" do
     expected = <<-HTML.strip_heredoc
       <div class="form-group">
-        <label class="" for="user_email">Email</label>
+        <label for="user_email">Email</label>
         <input class="form-control" id="user_email" name="user[email]" type="text" value="steve@example.com" />
       </div>
     HTML
@@ -174,7 +174,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
   test "help messages to look up I18n automatically" do
     expected = <<-HTML.strip_heredoc
       <div class="form-group">
-        <label class="" for="user_password">Password</label>
+        <label for="user_password">Password</label>
         <input class="form-control" id="user_password" name="user[password]" type="text" value="secret" />
         <small class="form-text text-muted">A good password should be at least six characters long</small>
       </div>
@@ -203,7 +203,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
   test "help messages to ignore translation when user disables help" do
     expected = <<-HTML.strip_heredoc
       <div class="form-group">
-        <label class="" for="user_password">Password</label>
+        <label for="user_password">Password</label>
         <input class="form-control" id="user_password" name="user[password]" type="text" value="secret" />
       </div>
     HTML
@@ -323,7 +323,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
   test "adds class to wrapped form_group by a field" do
     expected = <<-HTML.strip_heredoc
       <div class="form-group none-margin">
-        <label class="" for="user_misc">Misc</label>
+        <label for="user_misc">Misc</label>
         <input class="form-control" id="user_misc" name="user[misc]" type="search" />
       </div>
     HTML
@@ -402,7 +402,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
   test "adding an icon to a field" do
     expected = <<-HTML.strip_heredoc
       <div class="form-group has-feedback">
-        <label class="" for="user_misc">Misc</label>
+        <label for="user_misc">Misc</label>
         <input class="form-control" id="user_misc" name="user[misc]" type="email" />
         <span class="glyphicon glyphicon-ok invalid-feedback"></span>
       </div>
@@ -435,7 +435,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
   test "adds data-attributes (or any other options) to wrapper" do
     expected = <<-HTML.strip_heredoc
       <div class="form-group" data-foo="bar">
-        <label class="" for="user_misc">Misc</label>
+        <label for="user_misc">Misc</label>
         <input class="form-control" id="user_misc" name="user[misc]" type="search" />
       </div>
     HTML
@@ -459,7 +459,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
 
     expected = <<-HTML.strip_heredoc
       <div class="form-group">
-        <label class="" for="user_nil">Foo</label>
+        <label for="user_nil">Foo</label>
       </div>
     HTML
     assert_equivalent_xml expected, output

--- a/test/bootstrap_form_test.rb
+++ b/test/bootstrap_form_test.rb
@@ -67,7 +67,7 @@ class BootstrapFormTest < ActionView::TestCase
       <form accept-charset="UTF-8" action="/users" method="post" role="form">
         <input name="utf8" type="hidden" value="&#x2713;" />
         <div class="form-group">
-          <label class="" for="email">Your Email</label>
+          <label for="email">Your Email</label>
           <input class="form-control" id="email" name="email" type="text" />
         </div>
       </form>
@@ -80,7 +80,7 @@ class BootstrapFormTest < ActionView::TestCase
       <form accept-charset="UTF-8" action="/users" method="post" role="form">
         <input name="utf8" type="hidden" value="&#x2713;" />
         <div class="form-group">
-          <label class="" for="ID">Email</label>
+          <label for="ID">Email</label>
           <input class="form-control" id="ID" name="NAME" type="text" />
         </div>
       </form>
@@ -418,7 +418,7 @@ class BootstrapFormTest < ActionView::TestCase
     builder = BootstrapForm::FormBuilder.new :other_model, nil, self, {}
     expected = <<-HTML.strip_heredoc
       <div class="form-group">
-        <label class="" for="other_model_email">Email</label>
+        <label for="other_model_email">Email</label>
         <input class="form-control" id="other_model_email" name="other_model[email]" type="text" />
       </div>
     HTML

--- a/test/bootstrap_radio_button_test.rb
+++ b/test/bootstrap_radio_button_test.rb
@@ -75,7 +75,7 @@ class BootstrapRadioButtonTest < ActionView::TestCase
     collection = [Address.new(id: 1, street: 'Foobar')]
     expected = <<-HTML.strip_heredoc
       <div class="form-group">
-        <label class="" for="user_misc">This is a radio button collection</label>
+        <label for="user_misc">This is a radio button collection</label>
         <div class="radio">
           <label for="user_misc_1">
             <input id="user_misc_1" name="user[misc]" type="radio" value="1" />
@@ -93,7 +93,7 @@ class BootstrapRadioButtonTest < ActionView::TestCase
     collection = [Address.new(id: 1, street: 'Foo'), Address.new(id: 2, street: 'Bar')]
     expected = <<-HTML.strip_heredoc
       <div class="form-group">
-        <label class="" for="user_misc">Misc</label>
+        <label for="user_misc">Misc</label>
         <div class="radio">
           <label for="user_misc_1">
             <input id="user_misc_1" name="user[misc]" type="radio" value="1" /> Foo
@@ -114,7 +114,7 @@ class BootstrapRadioButtonTest < ActionView::TestCase
     collection = [Address.new(id: 1, street: 'Foo'), Address.new(id: 2, street: 'Bar')]
     expected = <<-HTML.strip_heredoc
       <div class="form-group">
-        <label class="" for="user_misc">Misc</label>
+        <label for="user_misc">Misc</label>
         <label class="radio-inline" for="user_misc_1">
           <input id="user_misc_1" name="user[misc]" type="radio" value="1" /> Foo
         </label>
@@ -131,7 +131,7 @@ class BootstrapRadioButtonTest < ActionView::TestCase
     collection = [Address.new(id: 1, street: 'Foo'), Address.new(id: 2, street: 'Bar')]
     expected = <<-HTML.strip_heredoc
       <div class="form-group">
-        <label class="" for="user_misc">Misc</label>
+        <label for="user_misc">Misc</label>
         <div class="radio">
           <label for="user_misc_1">
             <input checked="checked" id="user_misc_1" name="user[misc]" type="radio" value="1" /> Foo
@@ -152,7 +152,7 @@ class BootstrapRadioButtonTest < ActionView::TestCase
     collection = [Address.new(id: 1, street: 'Foobar')]
     expected = <<-HTML.strip_heredoc
       <div class="form-group">
-        <label class="" for="user_misc">This is a radio button collection</label>
+        <label for="user_misc">This is a radio button collection</label>
         <div class="radio">
           <label for="user_misc_1">
             <input id="user_misc_1" name="user[misc]" type="radio" value="1" /> rabooF
@@ -169,7 +169,7 @@ class BootstrapRadioButtonTest < ActionView::TestCase
     collection = [Address.new(id: 1, street: 'Foobar')]
     expected = <<-HTML.strip_heredoc
       <div class="form-group">
-        <label class="" for="user_misc">This is a radio button collection</label>
+        <label for="user_misc">This is a radio button collection</label>
         <div class="radio">
           <label for="user_misc_address_1">
             <input id="user_misc_address_1" name="user[misc]" type="radio" value="address_1" /> Foobar
@@ -186,7 +186,7 @@ class BootstrapRadioButtonTest < ActionView::TestCase
     collection = [Address.new(id: 1, street: 'Foo'), Address.new(id: 2, street: 'Bar')]
     expected = <<-HTML.strip_heredoc
       <div class="form-group">
-        <label class="" for="user_misc">Misc</label>
+        <label for="user_misc">Misc</label>
         <div class="radio">
           <label for="user_misc_1">
             <input id="user_misc_1" name="user[misc]" type="radio" value="1" /> ooF
@@ -207,7 +207,7 @@ class BootstrapRadioButtonTest < ActionView::TestCase
     collection = [Address.new(id: 1, street: 'Foo'), Address.new(id: 2, street: 'Bar')]
     expected = <<-HTML.strip_heredoc
       <div class="form-group">
-        <label class="" for="user_misc">Misc</label>
+        <label for="user_misc">Misc</label>
         <div class="radio">
           <label for="user_misc_address_1">
             <input id="user_misc_address_1" name="user[misc]" type="radio" value="address_1" /> Foo
@@ -228,7 +228,7 @@ class BootstrapRadioButtonTest < ActionView::TestCase
     collection = [Address.new(id: 1, street: 'Foobar')]
     expected = <<-HTML.strip_heredoc
       <div class="form-group">
-        <label class="" for="user_misc">This is a radio button collection</label>
+        <label for="user_misc">This is a radio button collection</label>
         <div class="radio">
           <label for="user_misc_1">
             <input id="user_misc_1" name="user[misc]" type="radio" value="1" /> rabooF
@@ -245,7 +245,7 @@ class BootstrapRadioButtonTest < ActionView::TestCase
     collection = [Address.new(id: 1, street: 'Foobar')]
     expected = <<-HTML.strip_heredoc
       <div class="form-group">
-        <label class="" for="user_misc">This is a radio button collection</label>
+        <label for="user_misc">This is a radio button collection</label>
         <div class="radio">
           <label for="user_misc_address_1">
             <input id="user_misc_address_1" name="user[misc]" type="radio" value="address_1" /> Foobar
@@ -262,7 +262,7 @@ class BootstrapRadioButtonTest < ActionView::TestCase
     collection = [Address.new(id: 1, street: 'Foo'), Address.new(id: 2, street: 'Bar')]
     expected = <<-HTML.strip_heredoc
       <div class="form-group">
-        <label class="" for="user_misc">Misc</label>
+        <label for="user_misc">Misc</label>
         <div class="radio">
           <label for="user_misc_1">
             <input id="user_misc_1" name="user[misc]" type="radio" value="1" /> ooF
@@ -283,7 +283,7 @@ class BootstrapRadioButtonTest < ActionView::TestCase
     collection = [Address.new(id: 1, street: 'Foo'), Address.new(id: 2, street: 'Bar')]
     expected = <<-HTML.strip_heredoc
       <div class="form-group">
-        <label class="" for="user_misc">Misc</label>
+        <label for="user_misc">Misc</label>
         <div class="radio">
           <label for="user_misc_address_1">
             <input id="user_misc_address_1" name="user[misc]" type="radio" value="address_1" /> Foo

--- a/test/bootstrap_selects_test.rb
+++ b/test/bootstrap_selects_test.rb
@@ -101,7 +101,7 @@ class BootstrapSelectsTest < ActionView::TestCase
   test "selects with block use block as content" do
     expected = <<-HTML.strip_heredoc
       <div class="form-group">
-        <label class="" for="user_status">Status</label>
+        <label for="user_status">Status</label>
         <select class="form-control" name="user[status]" id="user_status">
           <option>Option 1</option>
           <option>Option 2</option>

--- a/test/bootstrap_selects_test.rb
+++ b/test/bootstrap_selects_test.rb
@@ -17,7 +17,7 @@ class BootstrapSelectsTest < ActionView::TestCase
   test "time zone selects are wrapped correctly" do
     expected = <<-HTML.strip_heredoc
       <div class="form-group">
-        <label class="" for="user_misc">Misc</label>
+        <label for="user_misc">Misc</label>
         <select class="form-control" id="user_misc" name="user[misc]">#{time_zone_options_for_select}</select>
       </div>
     HTML
@@ -27,7 +27,7 @@ class BootstrapSelectsTest < ActionView::TestCase
   test "selects are wrapped correctly" do
     expected = <<-HTML.strip_heredoc
       <div class="form-group">
-        <label class="" for="user_status">Status</label>
+        <label for="user_status">Status</label>
         <select class="form-control" id="user_status" name="user[status]">
           <option value="1">activated</option>
           <option value="2">blocked</option>
@@ -40,7 +40,7 @@ class BootstrapSelectsTest < ActionView::TestCase
   test "bootstrap_specific options are handled correctly" do
     expected = <<-HTML.strip_heredoc
       <div class="form-group">
-        <label class="" for="user_status">My Status Label</label>
+        <label for="user_status">My Status Label</label>
         <select class="form-control" id="user_status" name="user[status]">
           <option value="1">activated</option>
           <option value="2">blocked</option>
@@ -54,7 +54,7 @@ class BootstrapSelectsTest < ActionView::TestCase
   test "selects with options are wrapped correctly" do
     expected = <<-HTML.strip_heredoc
       <div class="form-group">
-        <label class="" for="user_status">Status</label>
+        <label for="user_status">Status</label>
         <select class="form-control" id="user_status" name="user[status]">
           <option value="">Please Select</option>
 
@@ -70,7 +70,7 @@ class BootstrapSelectsTest < ActionView::TestCase
   test "selects with both options and html_options are wrapped correctly" do
     expected = <<-HTML.strip_heredoc
       <div class="form-group">
-        <label class="" for="user_status">Status</label>
+        <label for="user_status">Status</label>
         <select class="form-control my-select" id="user_status" name="user[status]">
           <option value="">Please Select</option>
           <option value="1">activated</option>
@@ -84,7 +84,7 @@ class BootstrapSelectsTest < ActionView::TestCase
   test 'selects with addons are wrapped correctly' do
     expected = <<-HTML.strip_heredoc
       <div class="form-group">
-        <label class="" for="user_status">Status</label>
+        <label for="user_status">Status</label>
         <div class="input-group">
           <div class="input-group-prepend"><span class="input-group-text">Before</span></div>
           <select class="form-control" id="user_status" name="user[status]">
@@ -102,7 +102,7 @@ class BootstrapSelectsTest < ActionView::TestCase
     test "selects with block use block as content" do
       expected = <<-HTML.strip_heredoc
         <div class="form-group">
-          <label class="" for="user_status">Status</label>
+          <label for="user_status">Status</label>
           <select class="form-control" name="user[status]" id="user_status">
             <option>Option 1</option>
             <option>Option 2</option>
@@ -120,7 +120,7 @@ class BootstrapSelectsTest < ActionView::TestCase
   test "selects render labels properly" do
     expected = <<-HTML.strip_heredoc
       <div class="form-group">
-        <label class="" for="user_status">User Status</label>
+        <label for="user_status">User Status</label>
         <select class="form-control" id="user_status" name="user[status]">
           <option value="1">activated</option>
           <option value="2">blocked</option>
@@ -133,7 +133,7 @@ class BootstrapSelectsTest < ActionView::TestCase
   test "collection_selects are wrapped correctly" do
     expected = <<-HTML.strip_heredoc
       <div class="form-group">
-        <label class="" for="user_status">Status</label>
+        <label for="user_status">Status</label>
         <select class="form-control" id="user_status" name="user[status]"></select>
       </div>
     HTML
@@ -143,7 +143,7 @@ class BootstrapSelectsTest < ActionView::TestCase
   test "collection_selects with options are wrapped correctly" do
     expected = <<-HTML.strip_heredoc
       <div class="form-group">
-        <label class="" for="user_status">Status</label>
+        <label for="user_status">Status</label>
         <select class="form-control" id="user_status" name="user[status]">
           <option value="">Please Select</option>
         </select>
@@ -155,7 +155,7 @@ class BootstrapSelectsTest < ActionView::TestCase
   test "collection_selects with options and html_options are wrapped correctly" do
     expected = <<-HTML.strip_heredoc
       <div class="form-group">
-        <label class="" for="user_status">Status</label>
+        <label for="user_status">Status</label>
         <select class="form-control my-select" id="user_status" name="user[status]">
           <option value="">Please Select</option>
         </select>
@@ -167,7 +167,7 @@ class BootstrapSelectsTest < ActionView::TestCase
   test "grouped_collection_selects are wrapped correctly" do
     expected = <<-HTML.strip_heredoc
       <div class="form-group">
-        <label class="" for="user_status">Status</label>
+        <label for="user_status">Status</label>
         <select class="form-control" id="user_status" name="user[status]"></select>
       </div>
     HTML
@@ -177,7 +177,7 @@ class BootstrapSelectsTest < ActionView::TestCase
   test "grouped_collection_selects with options are wrapped correctly" do
     expected = <<-HTML.strip_heredoc
       <div class="form-group">
-        <label class="" for="user_status">Status</label>
+        <label for="user_status">Status</label>
         <select class="form-control" id="user_status" name="user[status]">
           <option value="">Please Select</option>
         </select>
@@ -189,7 +189,7 @@ class BootstrapSelectsTest < ActionView::TestCase
   test "grouped_collection_selects with options and html_options are wrapped correctly" do
     expected = <<-HTML.strip_heredoc
       <div class="form-group">
-        <label class="" for="user_status">Status</label>
+        <label for="user_status">Status</label>
         <select class="form-control my-select" id="user_status" name="user[status]">
           <option value="">Please Select</option>
         </select>
@@ -202,7 +202,7 @@ class BootstrapSelectsTest < ActionView::TestCase
     Timecop.freeze(Time.utc(2012, 2, 3)) do
       expected = <<-HTML.strip_heredoc
         <div class="form-group">
-          <label class="" for="user_misc">Misc</label>
+          <label for="user_misc">Misc</label>
           <div class="rails-bootstrap-forms-date-select">
             <select class="form-control" id="user_misc_1i" name="user[misc(1i)]">
               #{options_range(start: 2007, stop: 2017, selected: 2012)}
@@ -224,7 +224,7 @@ class BootstrapSelectsTest < ActionView::TestCase
     Timecop.freeze(Time.utc(2012, 2, 3)) do
       expected = <<-HTML.strip_heredoc
         <div class="form-group">
-          <label class="" for="user_misc">Misc</label>
+          <label for="user_misc">Misc</label>
           <div class="rails-bootstrap-forms-date-select">
             <select class="form-control" id="user_misc_1i" name="user[misc(1i)]">
               <option value=""></option>
@@ -250,7 +250,7 @@ class BootstrapSelectsTest < ActionView::TestCase
     Timecop.freeze(Time.utc(2012, 2, 3)) do
       expected = <<-HTML.strip_heredoc
         <div class="form-group">
-          <label class="" for="user_misc">Misc</label>
+          <label for="user_misc">Misc</label>
           <div class="rails-bootstrap-forms-date-select">
             <select class="form-control my-date-select" id="user_misc_1i" name="user[misc(1i)]">
               <option value=""></option>
@@ -275,7 +275,7 @@ class BootstrapSelectsTest < ActionView::TestCase
     Timecop.freeze(Time.utc(2012, 2, 3, 12, 0, 0)) do
       expected = <<-HTML.strip_heredoc
         <div class="form-group">
-          <label class="" for="user_misc">Misc</label>
+          <label for="user_misc">Misc</label>
           <div class="rails-bootstrap-forms-time-select">
             <input id="user_misc_1i" name="user[misc(1i)]" type="hidden" value="2012" />
             <input id="user_misc_2i" name="user[misc(2i)]" type="hidden" value="2" />
@@ -298,7 +298,7 @@ class BootstrapSelectsTest < ActionView::TestCase
     Timecop.freeze(Time.utc(2012, 2, 3, 12, 0, 0)) do
       expected = <<-HTML.strip_heredoc
         <div class="form-group">
-          <label class="" for="user_misc">Misc</label>
+          <label for="user_misc">Misc</label>
           <div class="rails-bootstrap-forms-time-select">
             <input id="user_misc_1i" name="user[misc(1i)]" type="hidden" value="1" />
             <input id="user_misc_2i" name="user[misc(2i)]" type="hidden" value="1" />
@@ -323,7 +323,7 @@ class BootstrapSelectsTest < ActionView::TestCase
     Timecop.freeze(Time.utc(2012, 2, 3, 12, 0, 0)) do
       expected = <<-HTML.strip_heredoc
         <div class="form-group">
-          <label class="" for="user_misc">Misc</label>
+          <label for="user_misc">Misc</label>
           <div class="rails-bootstrap-forms-time-select">
             <input id="user_misc_1i" name="user[misc(1i)]" type="hidden" value="1" />
             <input id="user_misc_2i" name="user[misc(2i)]" type="hidden" value="1" />
@@ -348,7 +348,7 @@ class BootstrapSelectsTest < ActionView::TestCase
     Timecop.freeze(Time.utc(2012, 2, 3, 12, 0, 0)) do
       expected = <<-HTML.strip_heredoc
         <div class="form-group">
-          <label class="" for="user_misc">Misc</label>
+          <label for="user_misc">Misc</label>
           <div class="rails-bootstrap-forms-datetime-select">
             <select class="form-control" id="user_misc_1i" name="user[misc(1i)]">
               #{options_range(start: 2007, stop: 2017, selected: 2012)}
@@ -378,7 +378,7 @@ class BootstrapSelectsTest < ActionView::TestCase
     Timecop.freeze(Time.utc(2012, 2, 3, 12, 0, 0)) do
       expected = <<-HTML.strip_heredoc
         <div class="form-group">
-          <label class="" for="user_misc">Misc</label>
+          <label for="user_misc">Misc</label>
           <div class="rails-bootstrap-forms-datetime-select">
             <select class="form-control" id="user_misc_1i" name="user[misc(1i)]">
               <option value=""></option>
@@ -413,7 +413,7 @@ class BootstrapSelectsTest < ActionView::TestCase
     Timecop.freeze(Time.utc(2012, 2, 3, 12, 0, 0)) do
       expected = <<-HTML.strip_heredoc
         <div class="form-group">
-          <label class="" for="user_misc">Misc</label>
+          <label for="user_misc">Misc</label>
           <div class="rails-bootstrap-forms-datetime-select">
             <select class="form-control my-datetime-select" id="user_misc_1i" name="user[misc(1i)]">
               <option value=""></option>

--- a/test/special_form_class_models_test.rb
+++ b/test/special_form_class_models_test.rb
@@ -16,7 +16,7 @@ class SpecialFormClassModelsTest < ActionView::TestCase
 
     expected = <<-HTML.strip_heredoc
       <div class="form-group">
-        <label class="" for="user_misc">Misc</label>
+        <label for="user_misc">Misc</label>
         <input class="form-control" id="user_misc" name="user[misc]" type="date" />
       </div>
     HTML
@@ -31,7 +31,7 @@ class SpecialFormClassModelsTest < ActionView::TestCase
 
     expected = <<-HTML.strip_heredoc
       <div class="form-group">
-        <label class="" for="user_misc">Misc</label>
+        <label for="user_misc">Misc</label>
         <input class="form-control" id="user_misc" name="user[misc]" type="date" />
       </div>
     HTML
@@ -48,7 +48,7 @@ class SpecialFormClassModelsTest < ActionView::TestCase
 
     expected = <<-HTML.strip_heredoc
       <div class="form-group">
-        <label class="" for="user_misc">Misc</label>
+        <label for="user_misc">Misc</label>
         <input class="form-control" id="user_misc" name="user[misc]" type="date" />
       </div>
     HTML


### PR DESCRIPTION
Check if any classes actually make it through to the label, so we don't generate a useless `class=""` on the label. Fixing this fixes a lot of `form_with` test cases that haven't yet been merged.

Fixes #382.