### PR TITLE
Fix expected string for one horizontal form test case.

### DIFF
--- a/test/bootstrap_form_group_test.rb
+++ b/test/bootstrap_form_group_test.rb
@@ -412,7 +412,7 @@ class BootstrapFormGroupTest < ActionView::TestCase
         <div class="col-sm-10 col-sm-offset-2">Hallo</div>
       </div>
       <div class="form-group row">
-        <label class="col-sm-2 required" for="user_email">Email</label>
+        <label class="col-form-label col-sm-2 required" for="user_email">Email</label>
         <div class="col-sm-10">
           <input class="form-control" id="user_email" name="user[email]" type="text" value="steve@example.com" />
         </div>


### PR DESCRIPTION
Addresses #397 and unblocks #379.

All other test cases in the same file that used the `@horizontal_form_builder` have class `col-form-label` on the `label` in the expected string, but the test at line 403 of `test/bootstrap_form_group_test.rb` didn't.

@mattbrictson could you please look at this closely, and make sure it was correct to simply change the expected string in the test case? 